### PR TITLE
Add popup button to append referral query parameter

### DIFF
--- a/hello.html
+++ b/hello.html
@@ -1,6 +1,7 @@
 <html>
   <body>
     <h1>Hello Extensions</h1>
+    <button id="update-url">Add Query Parameter</button>
     <script src="popup.js"></script>
   </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,7 @@
   "description": "Base Level Extension",
   "version": "1.0",
   "manifest_version": 3,
+  "permissions": ["tabs"],
   "action": {
     "default_popup": "hello.html",
     "default_icon": "hello_extensions.png"

--- a/popup.js
+++ b/popup.js
@@ -1,1 +1,22 @@
-console.log('This is a popup!');
+document.addEventListener('DOMContentLoaded', () => {
+  console.log('This is a popup!');
+
+  const button = document.getElementById('update-url');
+  if (!button) {
+    return;
+  }
+
+  button.addEventListener('click', () => {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      const tab = tabs[0];
+      if (!tab || !tab.id || !tab.url) {
+        return;
+      }
+
+      const url = new URL(tab.url);
+      url.search = 'ref=badger:123;buisID:55';
+      chrome.tabs.update(tab.id, { url: url.toString() });
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- Add `tabs` permission to manifest so popup can update active tab
- Introduce button in popup UI to trigger query parameter injection
- Implement script that updates current tab URL with `ref=badger:123;buisID:55`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check popup.js`


------
https://chatgpt.com/codex/tasks/task_e_6891a2ae46e0832bb920f5445692c6e8