### PR TITLE
Append query parameter without replacing existing ones

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -14,7 +14,8 @@ document.addEventListener('DOMContentLoaded', () => {
       }
 
       const url = new URL(tab.url);
-      url.search = 'ref=badger:123;buisID:55';
+      const param = 'ref=badger:123;buisID:55';
+      url.search = url.search ? `${url.search}&${param}` : `?${param}`;
       chrome.tabs.update(tab.id, { url: url.toString() });
     });
   });


### PR DESCRIPTION
## Summary
- Preserve existing query string and append `ref=badger:123;buisID:55` when updating the active tab URL

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68926d523344832b847bf21875c469b7