### PR TITLE
Set cookie instead of updating URL

### DIFF
--- a/hello.html
+++ b/hello.html
@@ -1,7 +1,7 @@
 <html>
   <body>
     <h1>Hello Extensions</h1>
-    <button id="update-url">Add Query Parameter</button>
+    <button id="add-cookie">Add Cookie</button>
     <script src="popup.js"></script>
   </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,8 @@
   "description": "Base Level Extension",
   "version": "1.0",
   "manifest_version": 3,
-  "permissions": ["tabs"],
+  "permissions": ["tabs", "cookies"],
+  "host_permissions": ["<all_urls>"],
   "action": {
     "default_popup": "hello.html",
     "default_icon": "hello_extensions.png"

--- a/popup.js
+++ b/popup.js
@@ -1,7 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   console.log('This is a popup!');
 
-  const button = document.getElementById('update-url');
+  const button = document.getElementById('add-cookie');
   if (!button) {
     return;
   }
@@ -13,10 +13,11 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
       }
 
-      const url = new URL(tab.url);
-      const param = 'ref=badger:123;buisID:55';
-      url.search = url.search ? `${url.search}&${param}` : `?${param}`;
-      chrome.tabs.update(tab.id, { url: url.toString() });
+      chrome.cookies.set({
+        url: tab.url,
+        name: 'uuid',
+        value: '1111'
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary
- Replace URL query parameter update with setting a `uuid=1111` cookie for the active tab
- Add required cookie permissions and host permissions
- Update popup HTML to use `Add Cookie` button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689283fe4d74832b92f54b0d6b1a0472