### PR TITLE
Skip cookie when ref has badger uuid

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -12,16 +12,27 @@ document.addEventListener('DOMContentLoaded', () => {
         chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
             const tab = tabs[0];
             if (!tab || !tab.id || !tab.url) {
-            return;
-        }
+                return;
+            }
 
-       chrome.cookies.set({
-        url: tab.url,
-        name: 'uuid',
-        value: '1111'
-      });
+            try {
+                const urlObj = new URL(tab.url);
+                const refValue = urlObj.searchParams.get('ref');
+                const uuidPattern = /^badger:[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+                if (refValue && uuidPattern.test(refValue)) {
+                    return;
+                }
+            } catch (e) {
+                // ignore invalid URLs and continue to set cookie
+            }
+
+            chrome.cookies.set({
+                url: tab.url,
+                name: 'uuid',
+                value: '1111'
+            });
+        });
     });
-  });
 });
 
 


### PR DESCRIPTION
## Summary
- Don't set the `uuid` cookie if the active tab's URL already includes a `ref=badger:<uuid>` query parameter (handles URL-encoded versions as well)

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689293ea91bc832b90d254e46b0bb72d