### PR TITLE
Redirect out and back into checkout after cookie set

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -30,6 +30,25 @@ document.addEventListener('DOMContentLoaded', () => {
                 url: tab.url,
                 name: 'uuid',
                 value: '1111'
+            }, () => {
+                const originalUrl = tab.url;
+                let redirectUrl;
+                try {
+                    const urlObj = new URL(originalUrl);
+                    redirectUrl = urlObj.origin;
+                } catch (e) {
+                    redirectUrl = originalUrl;
+                }
+
+                const returnToCheckout = (tabId, changeInfo) => {
+                    if (tabId === tab.id && changeInfo.status === 'complete') {
+                        chrome.tabs.onUpdated.removeListener(returnToCheckout);
+                        chrome.tabs.update(tab.id, { url: originalUrl });
+                    }
+                };
+
+                chrome.tabs.onUpdated.addListener(returnToCheckout);
+                chrome.tabs.update(tab.id, { url: redirectUrl });
             });
         });
     });


### PR DESCRIPTION
## Summary
- Redirect away from checkout and return after setting cookie so Shopify script injection can capture new UUID

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/extension/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689652e4236c832bb100fc1e25b2266f