### PR TITLE
Redirect out and back into checkout after cookie set

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -30,6 +30,22 @@ document.addEventListener('DOMContentLoaded', () => {
                 url: tab.url,
                 name: 'uuid',
                 value: '1111'
+            }, () => {
+                const originalUrl = tab.url;
+                let redirectUrl;
+                try {
+                    const urlObj = new URL(originalUrl);
+                    redirectUrl = urlObj.origin;
+                } catch (e) {
+                    redirectUrl = originalUrl;
+                }
+
+                chrome.tabs.update(tab.id, { url: redirectUrl }, () => {
+                    // return to checkout after briefly leaving
+                    setTimeout(() => {
+                        chrome.tabs.update(tab.id, { url: originalUrl });
+                    }, 1000);
+                });
             });
         });
     });


### PR DESCRIPTION
## Summary
- Redirect to store origin after setting UUID cookie
- Automatically return to original checkout after brief delay

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/extension/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689652e4236c832bb100fc1e25b2266f