### PR TITLE
Ensure order is recreated after applying cookie

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -41,9 +41,15 @@ document.addEventListener('DOMContentLoaded', () => {
                 }
 
                 chrome.tabs.update(tab.id, { url: redirectUrl }, () => {
-                    // return to checkout after briefly leaving
+                    // recreate the order before returning to the original page
                     setTimeout(() => {
-                        chrome.tabs.update(tab.id, { url: originalUrl });
+                        fetch(originalUrl, { credentials: 'include' })
+                            .catch(() => {
+                                // Ignore errors recreating the order
+                            })
+                            .finally(() => {
+                                chrome.tabs.update(tab.id, { url: originalUrl });
+                            });
                     }, 1000);
                 });
             });


### PR DESCRIPTION
## Summary
- Recreate the Shopify order after applying the cookie and leaving checkout

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_6896805c04e8832b805c424f1c5cc1a4