### PR TITLE
Add cookie-based redirect to new Shopify checkout

### DIFF
--- a/content.js
+++ b/content.js
@@ -8,10 +8,23 @@
     return (hostMatch && pathMatch) || checkoutObj;
   };
 
+  const redirectWithoutToken = () => {
+    const { origin, pathname } = window.location;
+    if (pathname.startsWith('/checkouts/')) {
+      chrome.cookies.set(
+        { url: `${origin}/`, name: 'checkout_redirect', value: '1', path: '/' },
+        () => {
+          window.location.replace(`${origin}/checkout/`);
+        }
+      );
+    }
+  };
+
 
 
 
   if (isShopifyCheckout()) {
+    redirectWithoutToken();
     chrome.runtime.sendMessage({ action: 'openPopup' });
   }
 })();


### PR DESCRIPTION
## Summary
- set a cookie before redirecting tokenized checkout URLs to `/checkout/`
- trigger fresh Shopify checkout generation without existing token

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897ab3bbe8c832bb85d66f647c6d8b6