### PR TITLE
Redirect to pre-checkout

### DIFF
--- a/content.js
+++ b/content.js
@@ -36,7 +36,7 @@
       chrome.cookies.set(
         { url: `${origin}/`, name: 'checkout_redirect', value: '1', path: '/' },
         () => {
-          window.location.replace(`${origin}/checkout/`);
+          window.location.replace(`${origin}/pre-checkout/`);
         }
       );
     }

--- a/popup.js
+++ b/popup.js
@@ -38,7 +38,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     path: '/',
                 },
                 () => {
-                    const redirectUrl = `${urlObj.origin}/checkout`;
+                    const redirectUrl = `${urlObj.origin}/pre-checkout`;
                     chrome.tabs.update(tab.id, { url: redirectUrl });
                 }
             );


### PR DESCRIPTION
## Summary
- Redirect checkout cookie handler to `/pre-checkout/`
- Update popup redirect target to `/pre-checkout`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898211f5040832b87f67b406f1e9d86