### PR TITLE
Redirect to cart and auto-checkout on Add Cookie click

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,8 @@
   "manifest_version": 3,
   "permissions": [
     "tabs",
-    "cookies"
+    "cookies",
+    "scripting"
   ],
   "host_permissions": [
     "<all_urls>"


### PR DESCRIPTION
## Summary
- Restore Add Cookie button and attach cookie logic to it
- After setting UUID cookie, navigate to /cart and automatically click checkout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689837434f34832b9673635a6058e93e