### PR TITLE
Ensure sequential cart navigation and checkout

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -2,65 +2,66 @@ document.addEventListener('DOMContentLoaded', () => {
   const addCookieButton = document.getElementById('add-cookie');
   if (!addCookieButton) return;
 
-  addCookieButton.addEventListener('click', () => {
-    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-      const tab = tabs[0];
-      if (!tab || !tab.id || !tab.url) return;
-
-      let urlObj;
-      try {
-        urlObj = new URL(tab.url);
-      } catch (e) {
-        return;
-      }
-
-      const targetUrl = `${urlObj.origin}/cart`;
-
-      const onCartLoaded = (updatedTabId, info) => {
-        if (updatedTabId === tab.id && info.status === 'complete') {
-          chrome.tabs.onUpdated.removeListener(onCartLoaded);
-
-          chrome.cookies.set(
-            {
-              url: `${urlObj.origin}/`,
-              name: 'uuid',
-              value: 'b88a40af-0e8b-42d3-bda7-fd6bdb0427a3',
-              path: '/',
-            },
-            () => {
-              const onReloaded = (reloadedTabId, reloadInfo) => {
-                if (reloadedTabId === tab.id && reloadInfo.status === 'complete') {
-                  chrome.tabs.onUpdated.removeListener(onReloaded);
-                  chrome.scripting.executeScript({
-                    target: { tabId: tab.id },
-                    func: () => {
-                      const selectors = [
-                        'button[name="checkout"]',
-                        '#checkout',
-                        'button.checkout',
-                        'a.checkout',
-                      ];
-                      for (const sel of selectors) {
-                        const el = document.querySelector(sel);
-                        if (el) {
-                          el.click();
-                          break;
-                        }
-                      }
-                    },
-                  });
-                }
-              };
-
-              chrome.tabs.onUpdated.addListener(onReloaded);
-              chrome.tabs.reload(tab.id);
-            }
-          );
+  const waitForTab = (tabId) =>
+    new Promise((resolve) => {
+      const listener = (updatedTabId, info) => {
+        if (updatedTabId === tabId && info.status === 'complete') {
+          chrome.tabs.onUpdated.removeListener(listener);
+          resolve();
         }
       };
+      chrome.tabs.onUpdated.addListener(listener);
+    });
 
-      chrome.tabs.onUpdated.addListener(onCartLoaded);
-      chrome.tabs.update(tab.id, { url: targetUrl });
+  const setCookie = (details) =>
+    new Promise((resolve) => {
+      chrome.cookies.set(details, resolve);
+    });
+
+  addCookieButton.addEventListener('click', async () => {
+    const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+    const tab = tabs[0];
+    if (!tab || !tab.id || !tab.url) return;
+
+    let urlObj;
+    try {
+      urlObj = new URL(tab.url);
+    } catch (e) {
+      return;
+    }
+
+    const targetUrl = `${urlObj.origin}/cart`;
+
+    await chrome.tabs.update(tab.id, { url: targetUrl });
+    await waitForTab(tab.id);
+
+    await setCookie({
+      url: `${urlObj.origin}/`,
+      name: 'uuid',
+      value: 'b88a40af-0e8b-42d3-bda7-fd6bdb0427a3',
+      path: '/',
+    });
+
+    await chrome.tabs.reload(tab.id);
+    await waitForTab(tab.id);
+
+    await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      func: () => {
+        const selectors = [
+          'button[name="checkout"]',
+          '#checkout',
+          'button.checkout',
+          'a.checkout',
+        ];
+        for (const sel of selectors) {
+          const el = document.querySelector(sel);
+          if (el) {
+            el.click();
+            break;
+          }
+        }
+      },
     });
   });
 });


### PR DESCRIPTION
## Summary
- Refactor popup script to use async/await for strict step ordering
- Wait for tab loads, set UUID cookie, reload, then click checkout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689844f40f9c832bb37de6f1aa74c0c2