### PR TITLE
Disable automatic checkout click

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -57,7 +57,7 @@ document.addEventListener('DOMContentLoaded', () => {
         for (const sel of selectors) {
           const el = document.querySelector(sel);
           if (el) {
-            el.click();
+            // el.click();
             break;
           }
         }


### PR DESCRIPTION
## Summary
- stop extension from auto-clicking checkout buttons by commenting out the click call

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898466c684c832ba2089f9711ed1907