### PR TITLE
Enable delayed automatic checkout click

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -57,7 +57,9 @@ document.addEventListener('DOMContentLoaded', () => {
         for (const sel of selectors) {
           const el = document.querySelector(sel);
           if (el) {
-            // el.click();
+            setTimeout(() => {
+              el.click();
+            }, 2000);
             break;
           }
         }


### PR DESCRIPTION
## Summary
- Automatically click the checkout button after adding a cookie
- Delay checkout click by 2 seconds before triggering

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898ec951078832bb28b48a9c37d5b4a