### PR TITLE
Auto-open popup on Shopify checkout

### DIFF
--- a/background.js
+++ b/background.js
@@ -4,4 +4,35 @@ chrome.runtime.onMessage.addListener((message) => {
   }
 });
 
+const isShopifyCheckout = (url) => {
+  try {
+    const { hostname, pathname } = new URL(url);
+    if (hostname === 'checkout.shopify.com') return true;
+    if (hostname.endsWith('.myshopify.com') &&
+        (pathname.startsWith('/checkouts') || pathname.startsWith('/checkout')))
+      return true;
+    return pathname.includes('/checkouts/');
+  } catch {
+    return false;
+  }
+};
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  const url = changeInfo.url || tab.url;
+  if (url && isShopifyCheckout(url)) {
+    chrome.action.openPopup({ tabId });
+  }
+});
+
+chrome.tabs.onActivated.addListener(async ({ tabId }) => {
+  try {
+    const tab = await chrome.tabs.get(tabId);
+    if (tab.url && isShopifyCheckout(tab.url)) {
+      chrome.action.openPopup({ tabId });
+    }
+  } catch (e) {
+    // Ignore errors
+  }
+});
+
 


### PR DESCRIPTION
## Summary
- Automatically trigger the extension popup when navigating to or viewing Shopify checkout pages.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898f080935c832bb23fa36c9f17a6db