### PR TITLE
Add checkout overlay injection

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,31 @@
+/**
+ * README
+ * Load unpacked extension: open chrome://extensions, enable Developer mode,
+ * click "Load unpacked" and select this folder.
+ * Test: Navigate to a Shopify checkout page (e.g., https://checkout.shopify.com/...)
+ * and the extension should show the coupon overlay.
+ */
+
+function isCheckoutUrl(url) {
+  return /checkout\.shopify\.com|\.myshopify\.com|\/checkout(s)?/i.test(url);
+}
+
+function handleNavigation(details) {
+  if (isCheckoutUrl(details.url)) {
+    chrome.scripting.executeScript({
+      target: { tabId: details.tabId },
+      files: ['content.js'],
+    });
+  } else {
+    chrome.tabs.sendMessage(details.tabId, { type: 'REMOVE_COUPON_OVERLAY' }, () => {});
+  }
+}
+
+chrome.webNavigation.onCommitted.addListener(handleNavigation);
+chrome.webNavigation.onHistoryStateUpdated.addListener(handleNavigation);
+
 chrome.runtime.onMessage.addListener((message) => {
   if (message.action === 'openPopup') {
     chrome.action.openPopup();
   }
 });
-
-

--- a/content.js
+++ b/content.js
@@ -1,0 +1,142 @@
+(() => {
+  const OVERLAY_ID = 'coupon-overlay-root';
+  let escHandler = null;
+
+  function logTelemetry(event) {
+    console.log(`[coupon-overlay] ${event}`);
+  }
+
+  function hasCouponInput() {
+    const input = document.querySelector(
+      'input[name="checkout[reduction_code]"], input[name="reductionCode"], input[name*="discount"], input[name*="coupon"]'
+    );
+    if (!input) return false;
+    const style = window.getComputedStyle(input);
+    if (style.display === 'none' || style.visibility === 'hidden') return false;
+    const labelText = [
+      input.getAttribute('placeholder') || '',
+      ...(input.labels ? Array.from(input.labels).map(l => l.innerText) : [])
+    ].join(' ');
+    return /discount|coupon|gift/i.test(labelText);
+  }
+
+  function isCheckoutDom() {
+    if (window.Shopify && Shopify.Checkout) return true;
+    return hasCouponInput();
+  }
+
+  function removeOverlay() {
+    const el = document.getElementById(OVERLAY_ID);
+    if (el) {
+      el.remove();
+      logTelemetry('closed');
+    }
+    if (escHandler) {
+      document.removeEventListener('keydown', escHandler);
+      escHandler = null;
+    }
+  }
+
+  function makeDraggable(wrapper, header) {
+    let startX, startY, origX, origY, dragging = false;
+
+    header.addEventListener('mousedown', (e) => {
+      dragging = true;
+      startX = e.clientX;
+      startY = e.clientY;
+      const rect = wrapper.getBoundingClientRect();
+      origX = rect.left;
+      origY = rect.top;
+      wrapper.style.right = 'auto';
+      document.addEventListener('mousemove', onMove);
+      document.addEventListener('mouseup', onUp);
+    });
+
+    function onMove(e) {
+      if (!dragging) return;
+      const dx = e.clientX - startX;
+      const dy = e.clientY - startY;
+      wrapper.style.left = `${origX + dx}px`;
+      wrapper.style.top = `${origY + dy}px`;
+    }
+
+    function onUp() {
+      dragging = false;
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+    }
+  }
+
+  function injectOverlay() {
+    if (document.getElementById(OVERLAY_ID)) return;
+
+    const host = document.createElement('div');
+    host.id = OVERLAY_ID;
+    host.style.all = 'initial';
+    const shadow = host.attachShadow({ mode: 'open' });
+
+    fetch(chrome.runtime.getURL('styles.css'))
+      .then(resp => resp.text())
+      .then(css => {
+        const style = document.createElement('style');
+        style.textContent = css;
+        shadow.appendChild(style);
+
+        const wrapper = document.createElement('div');
+        wrapper.className = 'coupon-wrapper';
+        wrapper.innerHTML = `
+          <div class="coupon-header">
+            <span>Coupons found!</span>
+            <button class="coupon-close" aria-label="Close" tabindex="0">&times;</button>
+          </div>
+          <div class="coupon-body">Hello World</div>
+        `;
+        shadow.appendChild(wrapper);
+        document.documentElement.appendChild(host);
+
+        const closeBtn = shadow.querySelector('.coupon-close');
+        closeBtn.addEventListener('click', removeOverlay);
+        closeBtn.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter' || e.key === ' ') removeOverlay();
+        });
+
+        escHandler = (e) => {
+          if (e.key === 'Escape') removeOverlay();
+        };
+        document.addEventListener('keydown', escHandler);
+
+        makeDraggable(wrapper, shadow.querySelector('.coupon-header'));
+
+        logTelemetry('shown');
+      });
+  }
+
+  function checkAndInject() {
+    if (isCheckoutDom()) {
+      injectOverlay();
+      return true;
+    }
+    return false;
+  }
+
+  if (!checkAndInject()) {
+    const observer = new MutationObserver(() => {
+      if (checkAndInject()) observer.disconnect();
+    });
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+
+    let tries = 0;
+    const interval = setInterval(() => {
+      if (checkAndInject() || ++tries > 10) {
+        clearInterval(interval);
+        observer.disconnect();
+      }
+    }, 1000);
+  }
+
+  chrome.runtime.onMessage.addListener((msg) => {
+    if (msg && msg.type === 'REMOVE_COUPON_OVERLAY') {
+      removeOverlay();
+    }
+  });
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,8 @@
   "permissions": [
     "tabs",
     "cookies",
-    "scripting"
+    "scripting",
+    "webNavigation"
   ],
   "host_permissions": [
     "<all_urls>"
@@ -19,7 +20,6 @@
     "service_worker": "background.js"
   },
   "icons": {
-    "48": "hello_extensions.png",
-    "128": "hello_extensions.png"
+    "48": "hello_extensions.png"
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,47 @@
+.coupon-wrapper {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  z-index: 2147483647;
+  background: #fff;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  font-family: sans-serif;
+  animation: fadeIn 0.3s ease;
+  min-width: 200px;
+}
+
+.coupon-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px;
+  background: #f5f5f5;
+  cursor: move;
+  user-select: none;
+  border-bottom: 1px solid #ddd;
+  font-size: 14px;
+}
+
+.coupon-close {
+  background: none;
+  border: none;
+  font-size: 16px;
+  cursor: pointer;
+}
+
+.coupon-close:focus {
+  outline: 2px solid #000;
+}
+
+.coupon-body {
+  padding: 16px;
+  font-size: 20px;
+  text-align: center;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}


### PR DESCRIPTION
## Summary
- Inject content script on Shopify checkout navigation events
- Display dismissible “Hello World” coupon overlay with Shadow DOM and keyboard controls
- Provide overlay styles and maintain existing icons
- Remove superfluous 128×128 icon asset

## Testing
- `node --check background.js content.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689903c73b08832b9b8d2584d2b64669