### PR TITLE
Display Hello World overlay on /checkouts/ URLs

### DIFF
--- a/background.js
+++ b/background.js
@@ -7,7 +7,7 @@
  */
 
 function isCheckoutUrl(url) {
-  return /checkout\.shopify\.com|\.myshopify\.com|\/checkout(s)?/i.test(url);
+  return url.includes('/checkouts/');
 }
 
 function handleNavigation(details) {

--- a/content.js
+++ b/content.js
@@ -111,28 +111,8 @@
       });
   }
 
-  function checkAndInject() {
-    if (isCheckoutDom()) {
-      injectOverlay();
-      return true;
-    }
-    return false;
-  }
-
-  if (!checkAndInject()) {
-    const observer = new MutationObserver(() => {
-      if (checkAndInject()) observer.disconnect();
-    });
-    observer.observe(document.documentElement, { childList: true, subtree: true });
-
-    let tries = 0;
-    const interval = setInterval(() => {
-      if (checkAndInject() || ++tries > 10) {
-        clearInterval(interval);
-        observer.disconnect();
-      }
-    }, 1000);
-  }
+  // Always show the overlay when this content script executes.
+  injectOverlay();
 
   chrome.runtime.onMessage.addListener((msg) => {
     if (msg && msg.type === 'REMOVE_COUPON_OVERLAY') {


### PR DESCRIPTION
## Summary
- Trigger content script when a URL contains `/checkouts/`
- Always inject the Hello World overlay when the script runs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899094e5a28832b870301e943ae1de0