### PR TITLE
Show overlay on Shopify checkout pages

### DIFF
--- a/background.js
+++ b/background.js
@@ -6,14 +6,17 @@
  */
 
 function handleNavigation(details) {
-  chrome.scripting.executeScript({
-    target: { tabId: details.tabId },
-    files: ['content.js'],
-  });
+  if (details.url && details.url.includes('/checkouts/')) {
+    chrome.scripting.executeScript({
+      target: { tabId: details.tabId },
+      files: ['content.js'],
+    });
+  }
 }
 
-chrome.webNavigation.onCommitted.addListener(handleNavigation);
-chrome.webNavigation.onHistoryStateUpdated.addListener(handleNavigation);
+const filter = { url: [{ urlContains: '/checkouts/' }] };
+chrome.webNavigation.onCommitted.addListener(handleNavigation, filter);
+chrome.webNavigation.onHistoryStateUpdated.addListener(handleNavigation, filter);
 
 chrome.runtime.onMessage.addListener((message) => {
   if (message.action === 'openPopup') {

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,7 @@
     "webNavigation"
   ],
   "host_permissions": [
-    "<all_urls>"
+    "*://*/checkouts/*"
   ],
   "action": {
     "default_popup": "hello.html",


### PR DESCRIPTION
## Summary
- Inject coupon overlay only when visiting URLs containing `/checkouts/`
- Narrow host permissions to checkout paths

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689910d35114832b87729956b43df9cb