### PR TITLE
Expose stylesheet for checkout overlay

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -19,6 +19,12 @@
   "background": {
     "service_worker": "background.js"
   },
+  "web_accessible_resources": [
+    {
+      "resources": ["styles.css"],
+      "matches": ["<all_urls>"]
+    }
+  ],
   "icons": {
     "48": "hello_extensions.png"
   }


### PR DESCRIPTION
## Summary
- allow `styles.css` to be served to checkout pages by adding it to `web_accessible_resources`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68997f9d3d68832b907b19bd5b92b89a