### PR TITLE
Prevent multiple popups on checkout

### DIFF
--- a/background.js
+++ b/background.js
@@ -5,18 +5,27 @@
  * The extension will display a Hello World overlay on every page you visit.
  */
 
+const injectedTabs = new Set();
+
 function handleNavigation(details) {
-  if (details.url && details.url.includes('/checkouts/')) {
-    chrome.scripting.executeScript({
-      target: { tabId: details.tabId },
-      files: ['content.js'],
-    });
+  if (!details.url || !details.url.includes('/checkouts/')) {
+    injectedTabs.delete(details.tabId);
+    return;
   }
+
+  if (injectedTabs.has(details.tabId)) return;
+
+  injectedTabs.add(details.tabId);
+  chrome.scripting.executeScript({
+    target: { tabId: details.tabId },
+    files: ['content.js'],
+  });
 }
 
 const filter = { url: [{ urlContains: '/checkouts/' }] };
 chrome.webNavigation.onCommitted.addListener(handleNavigation, filter);
 chrome.webNavigation.onHistoryStateUpdated.addListener(handleNavigation, filter);
+chrome.tabs.onRemoved.addListener(tabId => injectedTabs.delete(tabId));
 
 chrome.runtime.onMessage.addListener((message) => {
   if (message.action === 'openPopup') {


### PR DESCRIPTION
## Summary
- Track tabs that already injected checkout overlay to avoid multiple popups
- Clean up tracking when navigating away or closing tab

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689985dcd354832bbb1edfa06778a1fa