### PR TITLE
Move coupon overlay to top-right

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,7 @@
 .coupon-wrapper {
   position: fixed;
   top: 10px;
-  left: 10px;
+  right: 10px;
   z-index: 2147483647;
   background: #fff;
   border: 1px solid #ccc;


### PR DESCRIPTION
## Summary
- show the injected coupon overlay in the top-right corner

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68998e4825c8832b8f777969f0eebc40