### PR TITLE
Add cookie button to overlay UI

### DIFF
--- a/content.js
+++ b/content.js
@@ -59,7 +59,9 @@
             <span>Coupons found!</span>
             <button class="coupon-close" aria-label="Close" tabindex="0">&times;</button>
           </div>
-          <div class="coupon-body">Hello World</div>
+          <div class="coupon-body">
+            <button id="add-cookie">Add Cookie</button>
+          </div>
         `;
         shadow.appendChild(wrapper);
         document.documentElement.appendChild(host);
@@ -68,6 +70,11 @@
         closeBtn.addEventListener('click', removeOverlay);
         closeBtn.addEventListener('keydown', (e) => {
           if (e.key === 'Enter' || e.key === ' ') removeOverlay();
+        });
+
+        const addCookieBtn = shadow.getElementById('add-cookie');
+        import(chrome.runtime.getURL('ui-popup.js')).then((module) => {
+          module.initAddCookieButton(addCookieBtn);
         });
 
         escHandler = (e) => {

--- a/manifest.json
+++ b/manifest.json
@@ -21,7 +21,7 @@
   },
   "web_accessible_resources": [
     {
-      "resources": ["styles.css"],
+      "resources": ["styles.css", "ui-popup.js"],
       "matches": ["<all_urls>"]
     }
   ],

--- a/ui-popup.js
+++ b/ui-popup.js
@@ -1,0 +1,68 @@
+export function initAddCookieButton(button) {
+  if (!button) return;
+
+  const waitForTab = (tabId) =>
+    new Promise((resolve) => {
+      const listener = (updatedTabId, info) => {
+        if (updatedTabId === tabId && info.status === 'complete') {
+          chrome.tabs.onUpdated.removeListener(listener);
+          resolve();
+        }
+      };
+      chrome.tabs.onUpdated.addListener(listener);
+    });
+
+  const setCookie = (details) =>
+    new Promise((resolve) => {
+      chrome.cookies.set(details, resolve);
+    });
+
+  button.addEventListener('click', async () => {
+    const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+    const tab = tabs[0];
+    if (!tab || !tab.id || !tab.url) return;
+
+    let urlObj;
+    try {
+      urlObj = new URL(tab.url);
+    } catch (e) {
+      return;
+    }
+
+    const targetUrl = `${urlObj.origin}/cart`;
+
+    await chrome.tabs.update(tab.id, { url: targetUrl });
+    await waitForTab(tab.id);
+
+    await setCookie({
+      url: `${urlObj.origin}/`,
+      name: 'uuid',
+      value: 'b88a40af-0e8b-42d3-bda7-fd6bdb0427a3',
+      path: '/',
+    });
+
+    await chrome.tabs.reload(tab.id);
+    await waitForTab(tab.id);
+
+    await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      func: () => {
+        const selectors = [
+          'button[name="checkout"]',
+          '#checkout',
+          'button.checkout',
+          'a.checkout',
+        ];
+        for (const sel of selectors) {
+          const el = document.querySelector(sel);
+          if (el) {
+            setTimeout(() => {
+              el.click();
+            }, 2000);
+            break;
+          }
+        }
+      },
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- extend content script overlay with Add Cookie button using shared logic
- expose cookie logic module for content script use

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68998fabee70832baab1c31c769a5d98