### PR TITLE
Handle reloads for checkout overlay injection

### DIFF
--- a/background.js
+++ b/background.js
@@ -13,6 +13,10 @@ function handleNavigation(details) {
     return;
   }
 
+  if (details.transitionType === 'reload' || details.transitionType === 'auto_reload') {
+    injectedTabs.delete(details.tabId);
+  }
+
   if (injectedTabs.has(details.tabId)) return;
 
   injectedTabs.add(details.tabId);


### PR DESCRIPTION
## Summary
- reinject content script after page reloads so UI reappears

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a3cc90674832b89c560bb8c647f96