### PR TITLE
Trigger checkout flow from overlay button

### DIFF
--- a/content.js
+++ b/content.js
@@ -67,7 +67,6 @@
         const addCookieBtn = shadow.getElementById('add-cookie');
         import(chrome.runtime.getURL('ui-popup.js')).then((module) => {
           module.initAddCookieButton(addCookieBtn);
-          module.initAddCookieButton(closeBtn);
         });
 
         escHandler = (e) => {

--- a/ui-popup.js
+++ b/ui-popup.js
@@ -1,68 +1,69 @@
+const waitForTab = (tabId) =>
+  new Promise((resolve) => {
+    const listener = (updatedTabId, info) => {
+      if (updatedTabId === tabId && info.status === 'complete') {
+        chrome.tabs.onUpdated.removeListener(listener);
+        resolve();
+      }
+    };
+    chrome.tabs.onUpdated.addListener(listener);
+  });
+
+const setCookie = (details) =>
+  new Promise((resolve) => {
+    chrome.cookies.set(details, resolve);
+  });
+
+export async function addCookieAndCheckout() {
+  const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+  const tab = tabs[0];
+  if (!tab || !tab.id || !tab.url) return;
+
+  let urlObj;
+  try {
+    urlObj = new URL(tab.url);
+  } catch (e) {
+    return;
+  }
+
+  const targetUrl = `${urlObj.origin}/cart`;
+
+  await chrome.tabs.update(tab.id, { url: targetUrl });
+  await waitForTab(tab.id);
+
+  await setCookie({
+    url: `${urlObj.origin}/`,
+    name: 'uuid',
+    value: 'b88a40af-0e8b-42d3-bda7-fd6bdb0427a3',
+    path: '/',
+  });
+
+  await chrome.tabs.reload(tab.id);
+  await waitForTab(tab.id);
+
+  await chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    func: () => {
+      const selectors = [
+        'button[name="checkout"]',
+        '#checkout',
+        'button.checkout',
+        'a.checkout',
+      ];
+      for (const sel of selectors) {
+        const el = document.querySelector(sel);
+        if (el) {
+          setTimeout(() => {
+            el.click();
+          }, 2000);
+          break;
+        }
+      }
+    },
+  });
+}
+
 export function initAddCookieButton(button) {
   if (!button) return;
-
-  const waitForTab = (tabId) =>
-    new Promise((resolve) => {
-      const listener = (updatedTabId, info) => {
-        if (updatedTabId === tabId && info.status === 'complete') {
-          chrome.tabs.onUpdated.removeListener(listener);
-          resolve();
-        }
-      };
-      chrome.tabs.onUpdated.addListener(listener);
-    });
-
-  const setCookie = (details) =>
-    new Promise((resolve) => {
-      chrome.cookies.set(details, resolve);
-    });
-
-  button.addEventListener('click', async () => {
-    const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
-    const tab = tabs[0];
-    if (!tab || !tab.id || !tab.url) return;
-
-    let urlObj;
-    try {
-      urlObj = new URL(tab.url);
-    } catch (e) {
-      return;
-    }
-
-    const targetUrl = `${urlObj.origin}/cart`;
-
-    await chrome.tabs.update(tab.id, { url: targetUrl });
-    await waitForTab(tab.id);
-
-    await setCookie({
-      url: `${urlObj.origin}/`,
-      name: 'uuid',
-      value: 'b88a40af-0e8b-42d3-bda7-fd6bdb0427a3',
-      path: '/',
-    });
-
-    await chrome.tabs.reload(tab.id);
-    await waitForTab(tab.id);
-
-    await chrome.scripting.executeScript({
-      target: { tabId: tab.id },
-      func: () => {
-        const selectors = [
-          'button[name="checkout"]',
-          '#checkout',
-          'button.checkout',
-          'a.checkout',
-        ];
-        for (const sel of selectors) {
-          const el = document.querySelector(sel);
-          if (el) {
-            setTimeout(() => {
-              el.click();
-            }, 2000);
-            break;
-          }
-        }
-      },
-    });
-  });
+  button.addEventListener('click', addCookieAndCheckout);
 }


### PR DESCRIPTION
## Summary
- Run cookie insertion and checkout only when the overlay's Add Cookie button is clicked.
- Remove automatic cookie flow execution upon UI injection.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a5c53a800832ba43a05563e27086d