### PR TITLE
Fix overlay not appearing on initial checkout navigation

### DIFF
--- a/background.js
+++ b/background.js
@@ -8,6 +8,8 @@
 const injectedTabs = new Set();
 
 function handleNavigation(details) {
+  // Ignore subframe navigations to ensure we inject only on the main page
+  if (details.frameId !== 0) return;
   if (!details.url || !details.url.includes('/checkouts/')) {
     injectedTabs.delete(details.tabId);
     return;


### PR DESCRIPTION
## Summary
- avoid injecting content script for subframe navigations so checkout popup appears on first visit

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a66647008832ba4ad27883fba4782