### PR TITLE
Add checkout workflow modal with status messaging

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,6 +1,101 @@
 (() => {
   const OVERLAY_ID = 'coupon-overlay-root';
   let escHandler = null;
+  let modal,
+    modalLoading,
+    modalResult,
+    resultTitle,
+    resultDesc;
+
+  const MODAL_CSS = `
+    #coupon-modal {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100vw;
+      height: 100vh;
+      background: rgba(0, 0, 0, 0.6);
+      display: none;
+      align-items: center;
+      justify-content: center;
+      z-index: 2147483647;
+    }
+    #coupon-modal.visible {
+      display: flex;
+    }
+    #coupon-modal .modal-content {
+      background: #fff;
+      padding: 24px;
+      border-radius: 8px;
+      text-align: center;
+      width: 80%;
+      max-width: 320px;
+      font-family: sans-serif;
+      position: relative;
+    }
+    #coupon-modal .loader {
+      width: 40px;
+      height: 40px;
+      border: 4px solid #f3f3f3;
+      border-top: 4px solid #3498db;
+      border-radius: 50%;
+      animation: spin 0.5s linear infinite;
+      margin: 0 auto 16px;
+    }
+    #coupon-modal ul {
+      list-style: disc;
+      padding-left: 20px;
+      text-align: left;
+      font-size: 14px;
+      margin: 0;
+    }
+    #coupon-modal .close-btn {
+      position: absolute;
+      top: 8px;
+      right: 8px;
+      background: none;
+      border: none;
+      font-size: 20px;
+      cursor: pointer;
+    }
+    #coupon-modal .hidden {
+      display: none;
+    }
+    #coupon-modal button {
+      margin-top: 16px;
+      padding: 8px 12px;
+      cursor: pointer;
+    }
+    @keyframes spin {
+      from { transform: rotate(0deg); }
+      to { transform: rotate(360deg); }
+    }
+  `;
+
+  function showModal() {
+    if (modal) {
+      modal.classList.add('visible');
+      modal.focus();
+    }
+  }
+
+  function resetModal() {
+    if (modalLoading && modalResult) {
+      modalLoading.classList.remove('hidden');
+      modalResult.classList.add('hidden');
+    }
+  }
+
+  function hideModal() {
+    if (modal) {
+      modal.classList.remove('visible');
+      resetModal();
+    }
+  }
+
+  function isModalVisible() {
+    return modal && modal.classList.contains('visible');
+  }
 
   function logTelemetry(event) {
     console.log(`[coupon-overlay] ${event}`);
@@ -45,47 +140,99 @@
     host.style.all = 'initial';
     const shadow = host.attachShadow({ mode: 'open' });
 
-      Promise.all([
-        fetch(chrome.runtime.getURL('styles.css')).then(resp => resp.text()),
-        fetch(chrome.runtime.getURL('ui-popup.html')).then(resp => resp.text()),
-      ]).then(([css, html]) => {
-        const style = document.createElement('style');
-        style.textContent = css;
-        shadow.appendChild(style);
+    Promise.all([
+      fetch(chrome.runtime.getURL('styles.css')).then(resp => resp.text()),
+      fetch(chrome.runtime.getURL('ui-popup.html')).then(resp => resp.text()),
+    ]).then(([css, html]) => {
+      const style = document.createElement('style');
+      style.textContent = css + MODAL_CSS;
+      shadow.appendChild(style);
 
-        const template = document.createElement('div');
-        template.innerHTML = html;
-        shadow.appendChild(template.firstElementChild);
-        document.documentElement.appendChild(host);
+      const template = document.createElement('div');
+      template.innerHTML = html;
+      shadow.appendChild(template.firstElementChild);
+      document.documentElement.appendChild(host);
 
-        const closeBtn = shadow.querySelector('.coupon-close');
-        closeBtn.addEventListener('click', removeOverlay);
-        closeBtn.addEventListener('keydown', (e) => {
-          if (e.key === 'Enter' || e.key === ' ') removeOverlay();
-        });
+      modal = document.createElement('div');
+      modal.id = 'coupon-modal';
+      modal.setAttribute('role', 'dialog');
+      modal.setAttribute('tabindex', '-1');
+      modal.innerHTML = `
+        <div class="modal-content">
+          <button class="close-btn" aria-label="Close">&times;</button>
+          <div class="loading">
+            <div class="loader"></div>
+            <ul>
+              <li>Checking for deals</li>
+              <li>Applying codes</li>
+            </ul>
+          </div>
+          <div class="result hidden">
+            <h2 class="result-title">All done!</h2>
+            <p class="result-desc">You're back at checkout with the best we could find.</p>
+            <button id="back-to-checkout">Back to Checkout</button>
+          </div>
+        </div>`;
+      shadow.appendChild(modal);
 
-        const addCookieBtn = shadow.getElementById('add-cookie');
-        if (addCookieBtn) {
-          addCookieBtn.addEventListener('click', () => {
-            chrome.runtime.sendMessage({ type: 'ADD_COOKIE' });
-          });
-        }
+      modalLoading = shadow.querySelector('#coupon-modal .loading');
+      modalResult = shadow.querySelector('#coupon-modal .result');
+      resultTitle = shadow.querySelector('#coupon-modal .result-title');
+      resultDesc = shadow.querySelector('#coupon-modal .result-desc');
+      const closeModalBtn = shadow.querySelector('#coupon-modal .close-btn');
+      const backBtn = shadow.getElementById('back-to-checkout');
+      closeModalBtn.addEventListener('click', hideModal);
+      backBtn.addEventListener('click', hideModal);
 
-        escHandler = (e) => {
-          if (e.key === 'Escape') removeOverlay();
-        };
-        document.addEventListener('keydown', escHandler);
-
-        logTelemetry('shown');
+      const closeBtn = shadow.querySelector('.coupon-close');
+      closeBtn.addEventListener('click', removeOverlay);
+      closeBtn.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') removeOverlay();
       });
+
+      const addCookieBtn = shadow.getElementById('add-cookie');
+      if (addCookieBtn) {
+        addCookieBtn.addEventListener('click', () => {
+          showModal();
+          chrome.runtime.sendMessage({ type: 'ADD_COOKIE' });
+        });
+      }
+
+      escHandler = (e) => {
+        if (e.key === 'Escape') {
+          if (isModalVisible()) {
+            hideModal();
+          } else {
+            removeOverlay();
+          }
+        }
+      };
+      document.addEventListener('keydown', escHandler);
+
+      logTelemetry('shown');
+    });
   }
 
   // Always show the overlay when this content script executes.
   injectOverlay();
 
   chrome.runtime.onMessage.addListener((msg) => {
-    if (msg && msg.type === 'REMOVE_COUPON_OVERLAY') {
+    if (!msg) return;
+    if (msg.type === 'REMOVE_COUPON_OVERLAY') {
       removeOverlay();
+    } else if (msg.type === 'RESULT') {
+      showModal();
+      if (modalLoading && modalResult) {
+        modalLoading.classList.add('hidden');
+        modalResult.classList.remove('hidden');
+        if (msg.status === 'error') {
+          resultTitle.textContent = 'Something went wrong';
+          resultDesc.textContent = 'Please try again.';
+        } else {
+          resultTitle.textContent = 'All done!';
+          resultDesc.textContent = "You're back at checkout with the best we could find.";
+        }
+      }
     }
   });
 })();


### PR DESCRIPTION
## Summary
- Show a full-screen modal with loader and messaging inside the checkout overlay
- Send workflow results from background to content script to update modal state
- Start the checkout workflow when the content script sends an ADD_COOKIE message

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a7c00dd40832bb9bb9da1c383ced4