### PR TITLE
Maintain loading overlay across cart navigation

### DIFF
--- a/content.js
+++ b/content.js
@@ -233,6 +233,9 @@
           resultDesc.textContent = "You're back at checkout with the best we could find.";
         }
       }
+    } else if (msg.type === 'SHOW_LOADING') {
+      resetModal();
+      showModal();
     }
   });
 })();

--- a/manifest.json
+++ b/manifest.json
@@ -10,7 +10,8 @@
     "webNavigation"
   ],
   "host_permissions": [
-    "*://*/checkouts/*"
+    "*://*/checkouts/*",
+    "*://*/cart*"
   ],
   "action": {
     "default_popup": "hello.html",


### PR DESCRIPTION
## Summary
- Handle new `SHOW_LOADING` messages in content script to keep overlay visible
- Inject content script on `/cart` pages and re-show loading after navigation
- Allow extension to access cart pages in host permissions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a8c9f7c60832ba0deb9d321920d95