### PR TITLE
Prevent multiple modals from opening

### DIFF
--- a/content.js
+++ b/content.js
@@ -6,6 +6,7 @@
     modalResult,
     resultTitle,
     resultDesc;
+  let modalOpenCount = 0;
 
   const MODAL_CSS = `
     #coupon-modal {
@@ -73,9 +74,10 @@
   `;
 
   function showModal() {
-    if (modal) {
+    if (modal && modalOpenCount === 0) {
       modal.classList.add('visible');
       modal.focus();
+      modalOpenCount++;
     }
   }
 
@@ -87,9 +89,10 @@
   }
 
   function hideModal() {
-    if (modal) {
+    if (modal && modalOpenCount > 0) {
       modal.classList.remove('visible');
       resetModal();
+      modalOpenCount--;
     }
   }
 
@@ -124,6 +127,7 @@
     const el = document.getElementById(OVERLAY_ID);
     if (el) {
       el.remove();
+      modalOpenCount = 0;
       logTelemetry('closed');
     }
     if (escHandler) {


### PR DESCRIPTION
## Summary
- Track the number of open modals and guard show/hide logic to avoid duplicate displays
- Reset modal counter when overlay is removed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a91fd77c4832b97c0591d8603a7d8