### PR TITLE
Add login popup to display API token

### DIFF
--- a/hello.html
+++ b/hello.html
@@ -2,6 +2,8 @@
   <body>
     <h1>Hello Extensions</h1>
     <button id="add-cookie">Add Cookie</button>
+    <button id="login">Login</button>
+    <div id="token"></div>
     <script src="popup.js"></script>
   </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -7,11 +7,14 @@
     "tabs",
     "cookies",
     "scripting",
-    "webNavigation"
+    "webNavigation",
+    "identity",
+    "storage"
   ],
   "host_permissions": [
     "*://*/checkouts/*",
-    "*://*/cart*"
+    "*://*/cart*",
+    "https://6f26ddd568cc.ngrok-free.app/*"
   ],
   "action": {
     "default_popup": "hello.html",
@@ -22,7 +25,7 @@
   },
   "web_accessible_resources": [
     {
-        "resources": ["styles.css", "ui-popup.html"],
+      "resources": ["styles.css", "ui-popup.html"],
       "matches": ["<all_urls>"]
     }
   ],

--- a/popup.js
+++ b/popup.js
@@ -1,69 +1,99 @@
 document.addEventListener('DOMContentLoaded', () => {
   const addCookieButton = document.getElementById('add-cookie');
-  if (!addCookieButton) return;
+  const loginButton = document.getElementById('login');
+  const tokenDiv = document.getElementById('token');
 
-  const waitForTab = (tabId) =>
-    new Promise((resolve) => {
-      const listener = (updatedTabId, info) => {
-        if (updatedTabId === tabId && info.status === 'complete') {
-          chrome.tabs.onUpdated.removeListener(listener);
-          resolve();
-        }
-      };
-      chrome.tabs.onUpdated.addListener(listener);
-    });
-
-  const setCookie = (details) =>
-    new Promise((resolve) => {
-      chrome.cookies.set(details, resolve);
-    });
-
-  addCookieButton.addEventListener('click', async () => {
-    const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
-    const tab = tabs[0];
-    if (!tab || !tab.id || !tab.url) return;
-
-    let urlObj;
-    try {
-      urlObj = new URL(tab.url);
-    } catch (e) {
-      return;
-    }
-
-    const targetUrl = `${urlObj.origin}/cart`;
-
-    await chrome.tabs.update(tab.id, { url: targetUrl });
-    await waitForTab(tab.id);
-
-    await setCookie({
-      url: `${urlObj.origin}/`,
-      name: 'uuid',
-      value: 'b88a40af-0e8b-42d3-bda7-fd6bdb0427a3',
-      path: '/',
-    });
-
-    await chrome.tabs.reload(tab.id);
-    await waitForTab(tab.id);
-
-    await chrome.scripting.executeScript({
-      target: { tabId: tab.id },
-      func: () => {
-        const selectors = [
-          'button[name="checkout"]',
-          '#checkout',
-          'button.checkout',
-          'a.checkout',
-        ];
-        for (const sel of selectors) {
-          const el = document.querySelector(sel);
-          if (el) {
-            setTimeout(() => {
-              el.click();
-            }, 2000);
-            break;
+  if (addCookieButton) {
+    const waitForTab = (tabId) =>
+      new Promise((resolve) => {
+        const listener = (updatedTabId, info) => {
+          if (updatedTabId === tabId && info.status === 'complete') {
+            chrome.tabs.onUpdated.removeListener(listener);
+            resolve();
           }
-        }
-      },
+        };
+        chrome.tabs.onUpdated.addListener(listener);
+      });
+
+    const setCookie = (details) =>
+      new Promise((resolve) => {
+        chrome.cookies.set(details, resolve);
+      });
+
+    addCookieButton.addEventListener('click', async () => {
+      const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+      const tab = tabs[0];
+      if (!tab || !tab.id || !tab.url) return;
+
+      let urlObj;
+      try {
+        urlObj = new URL(tab.url);
+      } catch (e) {
+        return;
+      }
+
+      const targetUrl = `${urlObj.origin}/cart`;
+
+      await chrome.tabs.update(tab.id, { url: targetUrl });
+      await waitForTab(tab.id);
+
+      await setCookie({
+        url: `${urlObj.origin}/`,
+        name: 'uuid',
+        value: 'b88a40af-0e8b-42d3-bda7-fd6bdb0427a3',
+        path: '/',
+      });
+
+      await chrome.tabs.reload(tab.id);
+      await waitForTab(tab.id);
+
+      await chrome.scripting.executeScript({
+        target: { tabId: tab.id },
+        func: () => {
+          const selectors = [
+            'button[name="checkout"]',
+            '#checkout',
+            'button.checkout',
+            'a.checkout',
+          ];
+          for (const sel of selectors) {
+            const el = document.querySelector(sel);
+            if (el) {
+              setTimeout(() => {
+                el.click();
+              }, 2000);
+              break;
+            }
+          }
+        },
+      });
     });
-  });
+  }
+
+  if (loginButton) {
+    loginButton.addEventListener('click', async () => {
+      if (tokenDiv) tokenDiv.textContent = '';
+      try {
+        const response = await fetch('https://6f26ddd568cc.ngrok-free.app/api/login-verify', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ username: 'demo', password: 'demo' })
+        });
+
+        if (!response.ok) {
+          throw new Error('Network response was not ok');
+        }
+
+        const data = await response.json();
+        const token = data.token || JSON.stringify(data);
+        if (tokenDiv) tokenDiv.textContent = token;
+        if (chrome.storage && chrome.storage.local) {
+          chrome.storage.local.set({ token });
+        }
+      } catch (err) {
+        console.error(err);
+        if (tokenDiv) tokenDiv.textContent = 'Login failed';
+      }
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- restore extension manifest and retain existing features while adding identity and storage permissions and login API host
- augment popup with Login button and token display
- extend popup script to handle login flow alongside existing cookie automation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d28638b74832ba8f37f2677b58048