### PR TITLE
Add login popup window and authentication logic

### DIFF
--- a/background.js
+++ b/background.js
@@ -118,5 +118,7 @@ chrome.runtime.onMessage.addListener((msg, sender) => {
     addCookieAndCheckout();
   } else if (msg?.action === 'openPopup') {
     chrome.action.openPopup();
+  } else if (msg?.type === 'LOGIN_SUCCESS') {
+    console.log('User logged in', msg.data);
   }
 });

--- a/hello.html
+++ b/hello.html
@@ -2,7 +2,7 @@
   <body>
     <h1>Hello Extensions</h1>
     <button id="add-cookie">Add Cookie</button>
-    <button id="login">Login</button>
+    <button id="login">Log In</button>
     <div id="token"></div>
     <script src="popup.js"></script>
   </body>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Log In</title>
+  <style>
+    body {
+      margin: 0;
+      font-family: sans-serif;
+      background: #f5f5f5;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+    }
+    .container {
+      background: #ffffff;
+      padding: 24px;
+      border-radius: 8px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+      width: 100%;
+      max-width: 360px;
+    }
+    h2 {
+      margin-top: 0;
+      text-align: center;
+    }
+    .form-group {
+      margin-bottom: 16px;
+    }
+    input[type="email"],
+    input[type="password"] {
+      width: 100%;
+      padding: 8px;
+      box-sizing: border-box;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+    }
+    button {
+      width: 100%;
+      padding: 10px;
+      background: #007bff;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 16px;
+    }
+    button:hover {
+      background: #0056b3;
+    }
+    .error {
+      margin-top: 12px;
+      color: #d00;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h2>Log In</h2>
+    <form id="login-form">
+      <div class="form-group">
+        <input type="email" id="email" placeholder="Email" required />
+      </div>
+      <div class="form-group">
+        <input type="password" id="password" placeholder="Password" required />
+      </div>
+      <button type="submit">Log In</button>
+      <div id="error" class="error"></div>
+    </form>
+  </div>
+  <script src="login.js"></script>
+</body>
+</html>

--- a/login.js
+++ b/login.js
@@ -1,0 +1,34 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('login-form');
+  const emailInput = document.getElementById('email');
+  const passwordInput = document.getElementById('password');
+  const errorDiv = document.getElementById('error');
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    errorDiv.textContent = '';
+    const payload = {
+      username: emailInput.value,
+      password: passwordInput.value,
+    };
+    try {
+      const response = await fetch('http://localhost:8000/api/login/', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({}));
+        throw new Error(errData.detail || 'Login failed');
+      }
+      const data = await response.json();
+      await new Promise((resolve) => {
+        chrome.storage.local.set({ auth: data }, resolve);
+      });
+      chrome.runtime.sendMessage({ type: 'LOGIN_SUCCESS', data });
+      window.close();
+    } catch (err) {
+      errorDiv.textContent = err.message || 'Login failed';
+    }
+  });
+});

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,8 @@
   "host_permissions": [
     "*://*/checkouts/*",
     "*://*/cart*",
-    "https://6f26ddd568cc.ngrok-free.app/*"
+    "https://6f26ddd568cc.ngrok-free.app/*",
+    "http://localhost:8000/*"
   ],
   "action": {
     "default_popup": "hello.html",

--- a/popup.js
+++ b/popup.js
@@ -71,29 +71,13 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   if (loginButton) {
-    loginButton.addEventListener('click', async () => {
-      if (tokenDiv) tokenDiv.textContent = '';
-      try {
-        const response = await fetch('https://6f26ddd568cc.ngrok-free.app/api/login-verify', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ username: 'demo', password: 'demo' })
-        });
-
-        if (!response.ok) {
-          throw new Error('Network response was not ok');
-        }
-
-        const data = await response.json();
-        const token = data.token || JSON.stringify(data);
-        if (tokenDiv) tokenDiv.textContent = token;
-        if (chrome.storage && chrome.storage.local) {
-          chrome.storage.local.set({ token });
-        }
-      } catch (err) {
-        console.error(err);
-        if (tokenDiv) tokenDiv.textContent = 'Login failed';
-      }
+    loginButton.addEventListener('click', () => {
+      chrome.windows.create({
+        url: chrome.runtime.getURL('login.html'),
+        type: 'popup',
+        width: 480,
+        height: 700,
+      });
     });
   }
 });


### PR DESCRIPTION
## Summary
- Add `login.html` and `login.js` to present a styled login window and authenticate against `http://localhost:8000/api/login/`
- Open the login window from the extension popup in a 480x700 popup window
- Listen for login success in the background script and grant host permissions for localhost API

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d2ebc2100832b8c056768b59e1b6c