### PR TITLE
feat: show login and user info in popup

### DIFF
--- a/hello.html
+++ b/hello.html
@@ -1,9 +1,17 @@
 <html>
   <body>
-    <h1>Hello Extensions</h1>
-    <button id="add-cookie">Add Cookie</button>
-    <button id="login">Log In</button>
-    <div id="token"></div>
+    <div id="before-login">
+      <button id="login">Log In</button>
+    </div>
+    <div id="after-login" style="display: none;">
+      <div>
+        Welcome, <span id="user-name"></span>!
+      </div>
+      <div>
+        Points: <span id="user-points"></span>
+      </div>
+      <button id="add-cookie">Add Cookie</button>
+    </div>
     <script src="popup.js"></script>
   </body>
 </html>

--- a/popup.js
+++ b/popup.js
@@ -1,83 +1,107 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const addCookieButton = document.getElementById('add-cookie');
+  const beforeLogin = document.getElementById('before-login');
+  const afterLogin = document.getElementById('after-login');
   const loginButton = document.getElementById('login');
-  const tokenDiv = document.getElementById('token');
+  const addCookieButton = document.getElementById('add-cookie');
+  const nameSpan = document.getElementById('user-name');
+  const pointsSpan = document.getElementById('user-points');
 
-  if (addCookieButton) {
-    const waitForTab = (tabId) =>
-      new Promise((resolve) => {
-        const listener = (updatedTabId, info) => {
-          if (updatedTabId === tabId && info.status === 'complete') {
-            chrome.tabs.onUpdated.removeListener(listener);
-            resolve();
-          }
-        };
-        chrome.tabs.onUpdated.addListener(listener);
-      });
-
-    const setCookie = (details) =>
-      new Promise((resolve) => {
-        chrome.cookies.set(details, resolve);
-      });
-
-    addCookieButton.addEventListener('click', async () => {
-      const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
-      const tab = tabs[0];
-      if (!tab || !tab.id || !tab.url) return;
-
-      let urlObj;
-      try {
-        urlObj = new URL(tab.url);
-      } catch (e) {
-        return;
+  const render = () => {
+    chrome.storage.local.get('auth', ({ auth }) => {
+      if (auth && auth.user) {
+        const name = auth.user.name || auth.user.username || 'User';
+        const points = auth.user.points ?? auth.points ?? 0;
+        nameSpan.textContent = name;
+        pointsSpan.textContent = points;
+        beforeLogin.style.display = 'none';
+        afterLogin.style.display = 'block';
+      } else {
+        beforeLogin.style.display = 'block';
+        afterLogin.style.display = 'none';
       }
+    });
+  };
 
-      const targetUrl = `${urlObj.origin}/cart`;
+  const waitForTab = (tabId) =>
+    new Promise((resolve) => {
+      const listener = (updatedTabId, info) => {
+        if (updatedTabId === tabId && info.status === 'complete') {
+          chrome.tabs.onUpdated.removeListener(listener);
+          resolve();
+        }
+      };
+      chrome.tabs.onUpdated.addListener(listener);
+    });
 
-      await chrome.tabs.update(tab.id, { url: targetUrl });
-      await waitForTab(tab.id);
+  const setCookie = (details) =>
+    new Promise((resolve) => {
+      chrome.cookies.set(details, resolve);
+    });
 
-      await setCookie({
-        url: `${urlObj.origin}/`,
-        name: 'uuid',
-        value: 'b88a40af-0e8b-42d3-bda7-fd6bdb0427a3',
-        path: '/',
-      });
+  addCookieButton?.addEventListener('click', async () => {
+    const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+    const tab = tabs[0];
+    if (!tab || !tab.id || !tab.url) return;
 
-      await chrome.tabs.reload(tab.id);
-      await waitForTab(tab.id);
+    let urlObj;
+    try {
+      urlObj = new URL(tab.url);
+    } catch (e) {
+      return;
+    }
 
-      await chrome.scripting.executeScript({
-        target: { tabId: tab.id },
-        func: () => {
-          const selectors = [
-            'button[name="checkout"]',
-            '#checkout',
-            'button.checkout',
-            'a.checkout',
-          ];
-          for (const sel of selectors) {
-            const el = document.querySelector(sel);
-            if (el) {
-              setTimeout(() => {
-                el.click();
-              }, 2000);
-              break;
-            }
+    const targetUrl = `${urlObj.origin}/cart`;
+
+    await chrome.tabs.update(tab.id, { url: targetUrl });
+    await waitForTab(tab.id);
+
+    await setCookie({
+      url: `${urlObj.origin}/`,
+      name: 'uuid',
+      value: 'b88a40af-0e8b-42d3-bda7-fd6bdb0427a3',
+      path: '/',
+    });
+
+    await chrome.tabs.reload(tab.id);
+    await waitForTab(tab.id);
+
+    await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      func: () => {
+        const selectors = [
+          'button[name="checkout"]',
+          '#checkout',
+          'button.checkout',
+          'a.checkout',
+        ];
+        for (const sel of selectors) {
+          const el = document.querySelector(sel);
+          if (el) {
+            setTimeout(() => {
+              el.click();
+            }, 2000);
+            break;
           }
-        },
-      });
+        }
+      },
     });
-  }
+  });
 
-  if (loginButton) {
-    loginButton.addEventListener('click', () => {
-      chrome.windows.create({
-        url: chrome.runtime.getURL('login.html'),
-        type: 'popup',
-        width: 480,
-        height: 700,
-      });
+  loginButton?.addEventListener('click', () => {
+    chrome.windows.create({
+      url: chrome.runtime.getURL('login.html'),
+      type: 'popup',
+      width: 480,
+      height: 700,
     });
-  }
+  });
+
+  chrome.runtime.onMessage.addListener((msg) => {
+    if (msg?.type === 'LOGIN_SUCCESS') {
+      render();
+    }
+  });
+
+  render();
 });
+


### PR DESCRIPTION
## Summary
- Replace popup layout with login-aware views
- Display logged-in user's name and points with Add Cookie option
- Update popup script to toggle views and handle login message

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e3c71b128832bace2e883c4fc2038