### PR TITLE
Open popup with logged-in view after authentication

### DIFF
--- a/login.js
+++ b/login.js
@@ -25,7 +25,10 @@ document.addEventListener('DOMContentLoaded', () => {
       await new Promise((resolve) => {
         chrome.storage.local.set({ auth: data }, resolve);
       });
-      chrome.runtime.sendMessage({ type: 'LOGIN_SUCCESS', data });
+      await new Promise((resolve) =>
+        chrome.runtime.sendMessage({ type: 'LOGIN_SUCCESS', data }, resolve)
+      );
+      chrome.runtime.sendMessage({ action: 'openPopup' });
       window.close();
     } catch (err) {
       errorDiv.textContent = err.message || 'Login failed';


### PR DESCRIPTION
## Summary
- Ensure login success is sent before closing the login window
- Open the extension popup after a successful login so it renders the logged-in view

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e4072ec78832b8b5a17e1f6507e37