### PR TITLE
Improve popup login state handling

### DIFF
--- a/login.js
+++ b/login.js
@@ -22,13 +22,10 @@ document.addEventListener('DOMContentLoaded', () => {
         throw new Error(errData.detail || 'Login failed');
       }
       const data = await response.json();
-      await new Promise((resolve) => {
-        chrome.storage.local.set({ auth: data }, resolve);
-      });
       await new Promise((resolve) =>
-        chrome.runtime.sendMessage({ type: 'LOGIN_SUCCESS', data }, resolve)
+        chrome.storage.local.set({ auth: data }, resolve)
       );
-      chrome.runtime.sendMessage({ action: 'openPopup' });
+      chrome.runtime.sendMessage({ type: 'LOGIN_SUCCESS' });
       window.close();
     } catch (err) {
       errorDiv.textContent = err.message || 'Login failed';

--- a/popup.js
+++ b/popup.js
@@ -8,9 +8,18 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const render = () => {
     chrome.storage.local.get('auth', ({ auth }) => {
-      if (auth && auth.user) {
-        const name = auth.user.name || auth.user.username || 'User';
-        const points = auth.user.points ?? auth.points ?? 0;
+      const isLoggedIn = !!(auth && (auth.user || auth.token || auth.uuid));
+
+      if (isLoggedIn) {
+        const name =
+          auth?.user?.name ||
+          auth?.user?.username ||
+          auth?.name ||
+          auth?.email ||
+          'User';
+
+        const points = auth?.user?.points ?? auth?.points ?? 0;
+
         nameSpan.textContent = name;
         pointsSpan.textContent = points;
         beforeLogin.style.display = 'none';
@@ -98,6 +107,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
   chrome.runtime.onMessage.addListener((msg) => {
     if (msg?.type === 'LOGIN_SUCCESS') {
+      render();
+    }
+  });
+
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area === 'local' && changes.auth) {
       render();
     }
   });


### PR DESCRIPTION
## Summary
- use token/uuid to verify auth in popup and show user name/points
- refresh popup on auth storage changes
- simplify login success handling

## Testing
- `node --check popup.js`
- `node --check login.js`


------
https://chatgpt.com/codex/tasks/task_e_689e4cda4e44832ba74b1ea903ac98f1