### PR TITLE
Store customer ID and set cookie

### DIFF
--- a/background.js
+++ b/background.js
@@ -72,12 +72,25 @@ async function addCookieAndCheckout() {
     await waitForTab(tab.id);
     chrome.tabs.sendMessage(tab.id, { type: 'SHOW_LOADING' });
 
+    const { cusID } = await new Promise((resolve) =>
+      chrome.storage.local.get('cusID', resolve)
+    );
+
     await setCookie({
       url: `${urlObj.origin}/`,
       name: 'uuid',
       value: 'b88a40af-0e8b-42d3-bda7-fd6bdb0427a3',
       path: '/',
     });
+
+    if (cusID) {
+      await setCookie({
+        url: `${urlObj.origin}/`,
+        name: 'cusID',
+        value: cusID,
+        path: '/',
+      });
+    }
 
     await chrome.tabs.reload(tab.id);
     await waitForTab(tab.id);

--- a/login.js
+++ b/login.js
@@ -22,8 +22,9 @@ document.addEventListener('DOMContentLoaded', () => {
         throw new Error(errData.detail || 'Login failed');
       }
       const data = await response.json();
+      const cusID = data?.uuid;
       await new Promise((resolve) =>
-        chrome.storage.local.set({ auth: data }, resolve)
+        chrome.storage.local.set({ auth: data, cusID }, resolve)
       );
       chrome.runtime.sendMessage({ type: 'LOGIN_SUCCESS' });
       window.close();

--- a/popup.js
+++ b/popup.js
@@ -65,12 +65,25 @@ document.addEventListener('DOMContentLoaded', () => {
     await chrome.tabs.update(tab.id, { url: targetUrl });
     await waitForTab(tab.id);
 
+    const { cusID } = await new Promise((resolve) =>
+      chrome.storage.local.get('cusID', resolve)
+    );
+
     await setCookie({
       url: `${urlObj.origin}/`,
       name: 'uuid',
       value: 'b88a40af-0e8b-42d3-bda7-fd6bdb0427a3',
       path: '/',
     });
+
+    if (cusID) {
+      await setCookie({
+        url: `${urlObj.origin}/`,
+        name: 'cusID',
+        value: cusID,
+        path: '/',
+      });
+    }
 
     await chrome.tabs.reload(tab.id);
     await waitForTab(tab.id);
@@ -107,7 +120,7 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   logoutButton?.addEventListener('click', () => {
-    chrome.storage.local.remove('auth', () => {
+    chrome.storage.local.remove(['auth', 'cusID'], () => {
       chrome.runtime.sendMessage({ type: 'LOGOUT' });
       render();
     });


### PR DESCRIPTION
## Summary
- Save UUID from login response as `cusID`
- Set stored `cusID` alongside `uuid` cookie when adding cookies
- Clear stored customer ID on logout

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e682a8928832b89c55f7806659b62