### PR TITLE
Fetch updated points after login

### DIFF
--- a/login.js
+++ b/login.js
@@ -4,29 +4,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const passwordInput = document.getElementById('password');
   const errorDiv = document.getElementById('error');
 
-  const updatePoints = async () => {
-    const { auth } = await new Promise((resolve) =>
-      chrome.storage.local.get('auth', resolve)
-    );
-    const uuid = auth?.uuid;
-    if (!uuid) return;
-    try {
-      const resp = await fetch(
-        `http://localhost:8000/api/points/${uuid}/`
-      );
-      if (!resp.ok) return;
-      const data = await resp.json();
-      await new Promise((resolve) =>
-        chrome.storage.local.set(
-          { auth: { ...auth, points: data?.points ?? 0 } },
-          resolve
-        )
-      );
-    } catch (e) {
-      console.error('Failed to fetch points', e);
-    }
-  };
-
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
     errorDiv.textContent = '';
@@ -49,7 +26,6 @@ document.addEventListener('DOMContentLoaded', () => {
       await new Promise((resolve) =>
         chrome.storage.local.set({ auth: data, cusID }, resolve)
       );
-      await updatePoints();
       chrome.runtime.sendMessage({ type: 'LOGIN_SUCCESS' });
       window.close();
     } catch (err) {

--- a/popup.js
+++ b/popup.js
@@ -149,11 +149,11 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
-  chrome.runtime.onMessage.addListener((msg) => {
-    if (msg?.type === 'LOGIN_SUCCESS') {
-      updatePoints().then(render);
-    }
-  });
+    chrome.runtime.onMessage.addListener((msg) => {
+      if (msg?.type === 'LOGIN_SUCCESS') {
+        render();
+      }
+    });
 
   chrome.storage.onChanged.addListener((changes, area) => {
     if (area === 'local' && changes.auth) {

--- a/popup.js
+++ b/popup.js
@@ -7,7 +7,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const nameSpan = document.getElementById('user-name');
   const pointsSpan = document.getElementById('user-points');
 
-  const fetchPoints = async () => {
+  const updatePoints = async () => {
     const { auth } = await new Promise((resolve) =>
       chrome.storage.local.get('auth', resolve)
     );
@@ -151,7 +151,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   chrome.runtime.onMessage.addListener((msg) => {
     if (msg?.type === 'LOGIN_SUCCESS') {
-      fetchPoints().then(render);
+      updatePoints().then(render);
     }
   });
 
@@ -161,6 +161,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  fetchPoints().then(render);
+  updatePoints().then(render);
 });
 


### PR DESCRIPTION
## Summary
- fetch point totals from `/api/points/<uuid>/` and store in local storage after login
- refresh popup points display by invoking the same update when the popup opens or login completes

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68accc41db94832b9da564d65984d90d