### PR TITLE
Add redirect to discount checkout after button click

### DIFF
--- a/background.js
+++ b/background.js
@@ -111,6 +111,9 @@ async function addCookieAndCheckout() {
           if (el) {
             setTimeout(() => {
               el.click();
+              setTimeout(() => {
+                window.location.href = '/checkout?discount=FREESHIPPING2025';
+              }, 1500);
             }, 2000);
             break;
           }

--- a/popup.js
+++ b/popup.js
@@ -125,6 +125,9 @@ document.addEventListener('DOMContentLoaded', () => {
           if (el) {
             setTimeout(() => {
               el.click();
+              setTimeout(() => {
+                window.location.href = '/checkout?discount=FREESHIPPING2025';
+              }, 1500);
             }, 2000);
             break;
           }


### PR DESCRIPTION
## Summary
- Redirect to `/checkout?discount=FREESHIPPING2025` 1.5s after simulating checkout button click in background and popup scripts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af24bfac68832ba69babc1fce5be0d