### PR TITLE
Redirect to checkout with discount after click

### DIFF
--- a/background.js
+++ b/background.js
@@ -111,6 +111,9 @@ async function addCookieAndCheckout() {
           if (el) {
             setTimeout(() => {
               el.click();
+              setTimeout(() => {
+                window.location.href = '/checkout?discount=FREESHIPPING2025';
+              }, 1500);
             }, 2000);
             break;
           }

--- a/popup.js
+++ b/popup.js
@@ -125,6 +125,9 @@ document.addEventListener('DOMContentLoaded', () => {
           if (el) {
             setTimeout(() => {
               el.click();
+              setTimeout(() => {
+                window.location.href = '/checkout?discount=FREESHIPPING2025';
+              }, 1500);
             }, 2000);
             break;
           }


### PR DESCRIPTION
## Summary
- After clicking checkout, wait 1.5s then redirect to /checkout?discount=FREESHIPPING2025.
- Apply redirect logic in both background and popup scripts to ensure discount is used.

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af2c125738832b8e6b553bf6100815