### PR TITLE
Add discount query parameter when adding cookies

### DIFF
--- a/background.js
+++ b/background.js
@@ -66,7 +66,7 @@ async function addCookieAndCheckout() {
       return;
     }
 
-    const targetUrl = `${urlObj.origin}/cart`;
+    const targetUrl = `${urlObj.origin}/cart?discounts=FREESHIPPING2025`;
 
     await chrome.tabs.update(tab.id, { url: targetUrl });
     await waitForTab(tab.id);
@@ -112,7 +112,7 @@ async function addCookieAndCheckout() {
             setTimeout(() => {
               el.click();
               setTimeout(() => {
-                window.location.href = '/checkout?discount=FREESHIPPING2025';
+                window.location.href = '/checkout?discounts=FREESHIPPING2025';
               }, 1500);
             }, 2000);
             break;

--- a/popup.js
+++ b/popup.js
@@ -83,7 +83,7 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
 
-    const targetUrl = `${urlObj.origin}/cart`;
+    const targetUrl = `${urlObj.origin}/cart?discounts=FREESHIPPING2025`;
 
     await chrome.tabs.update(tab.id, { url: targetUrl });
     await waitForTab(tab.id);
@@ -126,7 +126,7 @@ document.addEventListener('DOMContentLoaded', () => {
             setTimeout(() => {
               el.click();
               setTimeout(() => {
-                window.location.href = '/checkout?discount=FREESHIPPING2025';
+                window.location.href = '/checkout?discounts=FREESHIPPING2025';
               }, 1500);
             }, 2000);
             break;


### PR DESCRIPTION
## Summary
- Ensure cart navigation includes `?discounts=FREESHIPPING2025`
- Redirect checkout with the same `discounts` query after adding cookies

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af488ff7cc832ba7bbaf95a4131b15