### PR TITLE
Delay coupon flow via discount landing

### DIFF
--- a/background.js
+++ b/background.js
@@ -66,6 +66,11 @@ async function addCookieAndCheckout() {
       return;
     }
 
+    const discountUrl = `${urlObj.origin}/discount/FREESHIPPING2025`;
+    await chrome.tabs.update(tab.id, { url: discountUrl });
+    await waitForTab(tab.id);
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
     const targetUrl = `${urlObj.origin}/cart?discounts=FREESHIPPING2025`;
 
     await chrome.tabs.update(tab.id, { url: targetUrl });


### PR DESCRIPTION
## Summary
- Open the store's `/discount/FREESHIPPING2025` page and wait briefly before proceeding
- Continue existing coupon flow after the delay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af68d7afa8832b9ce7ee3060bc5f1b