### PR TITLE
Keep loading overlay visible during redirects

### DIFF
--- a/background.js
+++ b/background.js
@@ -69,6 +69,7 @@ async function addCookieAndCheckout() {
     const discountUrl = `${urlObj.origin}/discount/FREESHIPPING2025`;
     await chrome.tabs.update(tab.id, { url: discountUrl });
     await waitForTab(tab.id);
+    chrome.tabs.sendMessage(tab.id, { type: 'SHOW_LOADING' });
     await new Promise((resolve) => setTimeout(resolve, 500));
 
     const targetUrl = `${urlObj.origin}/cart?discounts=FREESHIPPING2025`;
@@ -127,6 +128,8 @@ async function addCookieAndCheckout() {
     });
 
     await waitForTab(tab.id);
+    chrome.tabs.sendMessage(tab.id, { type: 'SHOW_LOADING' });
+    await new Promise((resolve) => setTimeout(resolve, 500));
     chrome.tabs.sendMessage(tab.id, { type: 'RESULT', status: 'success' });
   } catch (e) {
     if (tab.id) {


### PR DESCRIPTION
## Summary
- Re-show loading overlay after each navigation step, ensuring it's visible on the discount, cart, and final checkout pages
- Display loading screen on return to checkout before showing results

## Testing
- ⚠️ `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af815cf0b0832bae89771c0ea036a4