### PR TITLE
Handle discount pages and guard message sending

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
   "host_permissions": [
     "*://*/checkouts/*",
     "*://*/cart*",
-    "https://6f26ddd568cc.ngrok-free.app/*",
+    "https://0a1c36ecb4ec.ngrok-free.app/*",
     "http://localhost:8000/*"
   ],
   "action": {


### PR DESCRIPTION
## Summary
- Inject content script on discount pages so messages can be received
- Safely send runtime messages to avoid missing receiver errors
- Update host permissions to allow requests to new backend URL

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c7813850832ba6ab72f38921aaf9