### PR TITLE
Handle auth tokens in extension

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,65 @@
+function decodeJwt(token) {
+  try {
+    const payload = token.split('.')[1];
+    return JSON.parse(atob(payload));
+  } catch (e) {
+    return {};
+  }
+}
+
+function isExpired(exp) {
+  return !exp || Date.now() / 1000 >= exp;
+}
+
+async function saveAuth(data) {
+  const accessExp = decodeJwt(data.access)?.exp || 0;
+  const refreshExp = decodeJwt(data.refresh)?.exp || 0;
+  const authData = { ...data, accessExp, refreshExp };
+  await new Promise((resolve) => chrome.storage.local.set({ auth: authData }, resolve));
+}
+
+async function getAuth() {
+  return new Promise((resolve) => chrome.storage.local.get('auth', resolve));
+}
+
+async function refreshAccessToken() {
+  const { auth } = await getAuth();
+  if (!auth?.refresh || isExpired(auth.refreshExp)) {
+    throw new Error('Refresh token expired');
+  }
+  const resp = await fetch('http://localhost:8000/api/token/refresh/', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ refresh: auth.refresh }),
+  });
+  if (!resp.ok) {
+    throw new Error('Refresh failed');
+  }
+  const data = await resp.json();
+  const accessExp = decodeJwt(data.access)?.exp || 0;
+  const newAuth = { ...auth, access: data.access, accessExp };
+  await new Promise((resolve) => chrome.storage.local.set({ auth: newAuth }, resolve));
+  return data.access;
+}
+
+async function getValidAccessToken() {
+  const { auth } = await getAuth();
+  if (!auth?.access) {
+    throw new Error('No token');
+  }
+  if (isExpired(auth.accessExp)) {
+    return await refreshAccessToken();
+  }
+  return auth.access;
+}
+
+async function requireLogin() {
+  await new Promise((resolve) => chrome.storage.local.remove(['auth', 'cusID'], resolve));
+  chrome.windows.create({
+    url: chrome.runtime.getURL('login.html'),
+    type: 'popup',
+    width: 480,
+    height: 700,
+  });
+}
+

--- a/background.js
+++ b/background.js
@@ -1,3 +1,5 @@
+importScripts('auth.js');
+
 /**
  * README
  * Load unpacked extension: open chrome://extensions, enable Developer mode,
@@ -75,10 +77,14 @@ async function addCookieAndCheckout() {
     if (merchantUuid) {
       console.log('going to try')
       try {
+        const token = await getValidAccessToken().catch(async () => {
+          await requireLogin();
+          throw new Error('Auth required');
+        });
         const resp = await fetch(
           `https://0a1c36ecb4ec.ngrok-free.app/shopify/create-discount/bb60af85-0ebe-49e5-8175-65b37dde57d4/`,
-          { method: 'POST' }
-        
+          { method: 'POST', headers: { Authorization: `Bearer ${token}` } }
+
         );
         console.log('sent post')
         console.log('Response:', resp);

--- a/hello.html
+++ b/hello.html
@@ -13,6 +13,7 @@
       <button id="add-cookie">Add Cookie</button>
       <button id="logout">Log Out</button>
     </div>
+    <script src="auth.js"></script>
     <script src="popup.js"></script>
   </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -70,6 +70,7 @@
       <div id="error" class="error"></div>
     </form>
   </div>
+  <script src="auth.js"></script>
   <script src="login.js"></script>
 </body>
 </html>

--- a/login.js
+++ b/login.js
@@ -23,8 +23,9 @@ document.addEventListener('DOMContentLoaded', () => {
       }
       const data = await response.json();
       const cusID = data?.uuid;
+      await saveAuth(data);
       await new Promise((resolve) =>
-        chrome.storage.local.set({ auth: data, cusID }, resolve)
+        chrome.storage.local.set({ cusID }, resolve)
       );
       chrome.runtime.sendMessage({ type: 'LOGIN_SUCCESS' });
       window.close();

--- a/popup.js
+++ b/popup.js
@@ -7,6 +7,15 @@ document.addEventListener('DOMContentLoaded', () => {
   const nameSpan = document.getElementById('user-name');
   const pointsSpan = document.getElementById('user-points');
 
+  const fetchWithAuth = async (url, options = {}) => {
+    const token = await getValidAccessToken().catch(async () => {
+      await requireLogin();
+      throw new Error('Auth required');
+    });
+    const headers = { ...(options.headers || {}), Authorization: `Bearer ${token}` };
+    return fetch(url, { ...options, headers });
+  };
+
   const updatePoints = async () => {
     const { auth } = await new Promise((resolve) =>
       chrome.storage.local.get('auth', resolve)
@@ -14,7 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const uuid = auth?.uuid;
     if (!uuid) return;
     try {
-      const resp = await fetch(
+      const resp = await fetchWithAuth(
         `http://localhost:8000/api/points/${uuid}/`
       );
       if (!resp.ok) return;
@@ -90,7 +99,7 @@ document.addEventListener('DOMContentLoaded', () => {
     let couponName = '';
     if (merchantUuid) {
       try {
-        const resp = await fetch(
+        const resp = await fetchWithAuth(
           `http://localhost:8000/api/create-discount/${merchantUuid}/`,
           { method: 'POST' }
         );


### PR DESCRIPTION
## Summary
- Save access and refresh tokens with expirations
- Refresh access tokens and re-prompt login when refresh token expires
- Authorize coupon and points API requests with valid access tokens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9014147d4832bb9b4423b0631da1d