### PR TITLE
Handle JWT tokens and authenticate POST requests

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,55 @@
+function parseJwt(token) {
+  try {
+    const payload = token.split('.')[1];
+    const decoded = atob(payload);
+    return JSON.parse(decoded);
+  } catch (e) {
+    return null;
+  }
+}
+
+function isTokenExpired(token) {
+  const data = parseJwt(token);
+  if (!data || !data.exp) return true;
+  return Date.now() >= data.exp * 1000;
+}
+
+async function authFetch(url, options = {}) {
+  const { auth } = await new Promise((resolve) =>
+    chrome.storage.local.get('auth', resolve)
+  );
+  let access = auth?.access;
+  const refresh = auth?.refresh;
+  if (!access || !refresh) {
+    throw new Error('Not authenticated');
+  }
+
+  if (isTokenExpired(access)) {
+    const resp = await fetch('http://localhost:8000/api/token/refresh/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ refresh }),
+    });
+    if (resp.ok) {
+      const data = await resp.json();
+      access = data?.access;
+      await new Promise((resolve) =>
+        chrome.storage.local.set({ auth: { ...auth, access } }, resolve)
+      );
+    } else {
+      await new Promise((resolve) =>
+        chrome.storage.local.remove(['auth', 'cusID'], resolve)
+      );
+      throw new Error('Authentication expired');
+    }
+  }
+
+  options.headers = {
+    ...(options.headers || {}),
+    Authorization: `Bearer ${access}`,
+  };
+  return fetch(url, options);
+}
+
+self.authFetch = authFetch;
+self.isTokenExpired = isTokenExpired;

--- a/background.js
+++ b/background.js
@@ -5,6 +5,8 @@
  * The extension will display a Hello World overlay on every page you visit.
  */
 
+importScripts('auth.js');
+
 const injectedTabs = new Map();
 
 function handleNavigation(details) {
@@ -75,10 +77,9 @@ async function addCookieAndCheckout() {
     if (merchantUuid) {
       console.log('going to try')
       try {
-        const resp = await fetch(
+        const resp = await authFetch(
           `https://0a1c36ecb4ec.ngrok-free.app/shopify/create-discount/bb60af85-0ebe-49e5-8175-65b37dde57d4/`,
           { method: 'POST' }
-        
         );
         console.log('sent post')
         console.log('Response:', resp);

--- a/hello.html
+++ b/hello.html
@@ -13,6 +13,7 @@
       <button id="add-cookie">Add Cookie</button>
       <button id="logout">Log Out</button>
     </div>
+    <script src="auth.js"></script>
     <script src="popup.js"></script>
   </body>
 </html>

--- a/login.js
+++ b/login.js
@@ -22,9 +22,10 @@ document.addEventListener('DOMContentLoaded', () => {
         throw new Error(errData.detail || 'Login failed');
       }
       const data = await response.json();
-      const cusID = data?.uuid;
+      const { access, refresh, ...rest } = data || {};
+      const cusID = rest?.uuid;
       await new Promise((resolve) =>
-        chrome.storage.local.set({ auth: data, cusID }, resolve)
+        chrome.storage.local.set({ auth: { ...rest, access, refresh }, cusID }, resolve)
       );
       chrome.runtime.sendMessage({ type: 'LOGIN_SUCCESS' });
       window.close();

--- a/popup.js
+++ b/popup.js
@@ -90,7 +90,7 @@ document.addEventListener('DOMContentLoaded', () => {
     let couponName = '';
     if (merchantUuid) {
       try {
-        const resp = await fetch(
+        const resp = await authFetch(
           `http://localhost:8000/api/create-discount/${merchantUuid}/`,
           { method: 'POST' }
         );


### PR DESCRIPTION
## Summary
- store access and refresh tokens on login
- add auth helper to refresh expired access tokens
- send Authorization headers on all POST requests

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9082c8904832b87d8cab4a2b45ef6