### PR TITLE
Preserve updated refresh token during auth refresh

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -33,8 +33,12 @@ async function authFetch(url, options = {}) {
     if (resp.ok) {
       const data = await resp.json();
       access = data?.access;
+      const newRefresh = data?.refresh || refresh;
       await new Promise((resolve) =>
-        chrome.storage.local.set({ auth: { ...auth, access } }, resolve)
+        chrome.storage.local.set(
+          { auth: { ...auth, access, refresh: newRefresh } },
+          resolve
+        )
       );
     } else {
       await new Promise((resolve) =>


### PR DESCRIPTION
## Summary
- ensure authFetch stores a new refresh token returned from the refresh endpoint

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e2a55114832b8daed46c92a83987