### PR TITLE
Show login prompt for unauthenticated users

### DIFF
--- a/background.js
+++ b/background.js
@@ -173,5 +173,12 @@ chrome.runtime.onMessage.addListener((msg, sender) => {
     chrome.action.openPopup();
   } else if (msg?.type === 'LOGIN_SUCCESS') {
     console.log('User logged in', msg.data);
+  } else if (msg?.type === 'OPEN_LOGIN') {
+    chrome.windows.create({
+      url: chrome.runtime.getURL('login.html'),
+      type: 'popup',
+      width: 480,
+      height: 700,
+    });
   }
 });

--- a/content.js
+++ b/content.js
@@ -202,6 +202,38 @@
         });
       }
 
+      const beforeLogin = shadow.getElementById('before-login');
+      const afterLogin = shadow.getElementById('after-login');
+      const loginBtn = shadow.getElementById('login');
+
+      const renderAuth = () => {
+        chrome.storage.local.get('auth', ({ auth }) => {
+          const isLoggedIn = !!(auth && (auth.user || auth.token || auth.uuid));
+          if (beforeLogin) beforeLogin.style.display = isLoggedIn ? 'none' : 'block';
+          if (afterLogin) afterLogin.style.display = isLoggedIn ? 'block' : 'none';
+        });
+      };
+
+      loginBtn?.addEventListener('click', () => {
+        chrome.runtime.sendMessage({ type: 'OPEN_LOGIN' });
+      });
+
+      chrome.runtime.onMessage.addListener((msg) => {
+        if (msg?.type === 'LOGIN_SUCCESS' || msg?.type === 'LOGOUT') {
+          renderAuth();
+          if (msg?.type === 'LOGIN_SUCCESS') updatePoints();
+        }
+      });
+
+      chrome.storage.onChanged.addListener((changes, area) => {
+        if (area === 'local' && changes.auth) {
+          renderAuth();
+          updatePoints();
+        }
+      });
+
+      renderAuth();
+
       escHandler = (e) => {
         if (e.key === 'Escape') {
           if (isModalVisible()) {

--- a/hello.html
+++ b/hello.html
@@ -1,6 +1,7 @@
 <html>
   <body>
     <div id="before-login">
+      <p>Login to earn</p>
       <button id="login">Log In</button>
     </div>
     <div id="after-login" style="display: none;">

--- a/popup.js
+++ b/popup.js
@@ -44,13 +44,13 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const points = auth?.user?.points ?? auth?.points ?? 0;
 
-        nameSpan.textContent = name;
-        pointsSpan.textContent = points;
-        beforeLogin.style.display = 'none';
-        afterLogin.style.display = 'block';
+        if (nameSpan) nameSpan.textContent = name;
+        if (pointsSpan) pointsSpan.textContent = points;
+        if (beforeLogin) beforeLogin.style.display = 'none';
+        if (afterLogin) afterLogin.style.display = 'block';
       } else {
-        beforeLogin.style.display = 'block';
-        afterLogin.style.display = 'none';
+        if (beforeLogin) beforeLogin.style.display = 'block';
+        if (afterLogin) afterLogin.style.display = 'none';
       }
     });
   };

--- a/ui-popup.html
+++ b/ui-popup.html
@@ -4,7 +4,12 @@
     <button class="coupon-close" aria-label="Close" tabindex="0">&times;</button>
   </div>
   <div class="coupon-body">
-    <button id="add-cookie">Add Cookie</button>
-    <script src="popup.js"></script>
+    <div id="before-login">
+      <span>Login to earn</span>
+      <button id="login">Log In</button>
+    </div>
+    <div id="after-login" style="display: none;">
+      <button id="add-cookie">Add Cookie</button>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Display "Login to earn" message with login button when the user is not authenticated
- Hide login prompt and show Add Cookie button after login
- Guard popup script against missing DOM elements
- Ensure checkout overlay handles auth state and can open login window

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ba05088258832b8d02556de2019de1