### PR TITLE
Set uuid cookie to expire after 24 hours

### DIFF
--- a/background.js
+++ b/background.js
@@ -119,6 +119,7 @@ async function addCookieAndCheckout() {
         name: 'uuid',
         value: '732bf11f-07c9-433e-b8f8-19fd6f160602',
         path: '/',
+        expirationDate: Math.floor(Date.now() / 1000) + 60 * 60 * 24,
       }),
       cusID
         ? setCookie({

--- a/popup.js
+++ b/popup.js
@@ -119,6 +119,7 @@ document.addEventListener('DOMContentLoaded', () => {
       name: 'uuid',
       value: '4397b0db-7c7c-440a-89ac-4097b0d31854',
       path: '/',
+      expirationDate: Math.floor(Date.now() / 1000) + 60 * 60 * 24,
     });
 
     if (cusID) {


### PR DESCRIPTION
## Summary
- ensure uuid cookie expires after 24 hours in both background and popup scripts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba415e0068832ba54104728d4d0e95