### PR TITLE
Fix popup Add Cookie visibility

### DIFF
--- a/content.js
+++ b/content.js
@@ -227,7 +227,10 @@
           return true;
         }
         chrome.storage.local.get('auth', ({ auth }) => {
-          const isLoggedIn = !!(auth && (auth.user || auth.token || auth.uuid));
+          const isLoggedIn = !!(
+            auth &&
+            (auth.user || auth.token || auth.uuid || auth.access || auth.refresh)
+          );
           if (beforeLogin) beforeLogin.style.display = isLoggedIn ? 'none' : 'block';
           if (afterLogin) afterLogin.style.display = isLoggedIn ? 'block' : 'none';
           if (supporting) supporting.style.display = 'none';

--- a/popup.js
+++ b/popup.js
@@ -32,7 +32,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const render = () => {
     chrome.storage.local.get('auth', ({ auth }) => {
-      const isLoggedIn = !!(auth && (auth.user || auth.token || auth.uuid));
+      const isLoggedIn = !!(
+        auth &&
+        (auth.user || auth.token || auth.uuid || auth.access || auth.refresh)
+      );
 
       if (isLoggedIn) {
         const name =


### PR DESCRIPTION
## Summary
- consider access/refresh tokens when determining logged-in state in popup and overlay

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba496f2940832bbd49fef23f5c84a0