### PR TITLE
Monitor UUID changes to display creator support overlay

### DIFF
--- a/content.js
+++ b/content.js
@@ -301,11 +301,22 @@
     });
   }
 
-  // Always show the overlay when this content script executes unless a specific cookie is present.
+  // Show the overlay when we have a UUID that does not match the
+  // specific opt-out value. Some stores set or update the UUID cookie
+  // asynchronously after the page loads, so if we see the opt-out value
+  // initially we keep checking until it changes.
   const existingUuid = getUuidCookie();
   updatePoints();
   if (existingUuid !== SPECIFIC_UUID) {
     injectOverlay();
+  } else {
+    const uuidMonitor = setInterval(() => {
+      const currentUuid = getUuidCookie();
+      if (currentUuid && currentUuid !== SPECIFIC_UUID) {
+        clearInterval(uuidMonitor);
+        injectOverlay();
+      }
+    }, 1000);
   }
 
   chrome.runtime.onMessage.addListener((msg) => {


### PR DESCRIPTION
## Summary
- show overlay only when UUID differs from opted-out value
- monitor cookie for UUID change after load and inject overlay when needed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba4d0a4390832b921c3748f2504220