### PR TITLE
Handle UUID-driven popup states

### DIFF
--- a/content.js
+++ b/content.js
@@ -220,22 +220,33 @@
 
       const renderAuth = () => {
         const uuid = getUuidCookie();
-        if (uuid) {
-          if (beforeLogin) beforeLogin.style.display = 'none';
-          if (afterLogin) afterLogin.style.display = 'none';
-          if (supporting) supporting.style.display = 'block';
-          return true;
-        }
         chrome.storage.local.get('auth', ({ auth }) => {
           const isLoggedIn = !!(
             auth &&
             (auth.user || auth.token || auth.uuid || auth.access || auth.refresh)
           );
-          if (beforeLogin) beforeLogin.style.display = isLoggedIn ? 'none' : 'block';
-          if (afterLogin) afterLogin.style.display = isLoggedIn ? 'block' : 'none';
-          if (supporting) supporting.style.display = 'none';
+
+          if (!isLoggedIn) {
+            if (beforeLogin) beforeLogin.style.display = 'block';
+            if (afterLogin) afterLogin.style.display = 'none';
+            if (supporting) supporting.style.display = 'none';
+          } else if (!uuid) {
+            if (beforeLogin) beforeLogin.style.display = 'none';
+            if (afterLogin) afterLogin.style.display = 'block';
+            if (supporting) supporting.style.display = 'none';
+          } else if (uuid !== SPECIFIC_UUID) {
+            if (beforeLogin) beforeLogin.style.display = 'none';
+            if (afterLogin) afterLogin.style.display = 'none';
+            if (supporting) supporting.style.display = 'block';
+          } else {
+            if (beforeLogin) beforeLogin.style.display = 'none';
+            if (afterLogin) afterLogin.style.display = 'none';
+            if (supporting) supporting.style.display = 'none';
+            removeOverlay();
+          }
         });
-        return false;
+
+        return !!uuid;
       };
 
       loginBtn?.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- adjust popup auth rendering logic
- hide overlay when UUID matches opt-out value

## Testing
- `npm test` (fails: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_68ba4fb27c24832b8fe5a11f32d76233