### PR TITLE
Ensure injected UI opens on checkout navigation

### DIFF
--- a/background.js
+++ b/background.js
@@ -38,6 +38,11 @@ const filter = { url: [{ urlContains: '/checkouts/' }, { urlContains: '/cart' }]
 chrome.webNavigation.onCommitted.addListener(handleNavigation, filter);
 chrome.webNavigation.onHistoryStateUpdated.addListener(handleNavigation, filter);
 chrome.tabs.onRemoved.addListener(tabId => injectedTabs.delete(tabId));
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (changeInfo.status === 'complete' && tab.url) {
+    handleNavigation({ tabId, frameId: 0, url: tab.url });
+  }
+});
 
 const waitForTab = (tabId) =>
   new Promise((resolve) => {


### PR DESCRIPTION
## Summary
- Inject the extension UI when a tab finishes loading a checkout or cart page

## Testing
- `npm test` *(fails: ENOENT: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ba51e9e340832b8e3b9e1d0af6aaeb