### PR TITLE
Display creator name in support popup

### DIFF
--- a/background.js
+++ b/background.js
@@ -30,7 +30,7 @@ function handleNavigation(details) {
   injectedTabs.set(details.tabId, details.url);
   chrome.scripting.executeScript({
     target: { tabId: details.tabId },
-    files: ['content.js'],
+    files: ['auth.js', 'content.js'],
   });
 }
 

--- a/ui-popup.html
+++ b/ui-popup.html
@@ -12,7 +12,7 @@
       <button id="add-cookie">Add Cookie</button>
     </div>
     <div id="supporting-creator" style="display: none;">
-      <span>You are supporting a creator.</span>
+      <span>You are supporting <span id="creator-name"></span> with this purchase.</span>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Include auth.js when injecting content scripts
- Fetch content creator name and show `You are supporting <name> with this purchase` message

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68bb940fed34832bb458a429baa3ad1e