### PR TITLE
Set uuid cookie only when discount applied

### DIFF
--- a/background.js
+++ b/background.js
@@ -118,23 +118,31 @@ async function addCookieAndCheckout() {
       chrome.storage.local.get('cusID', resolve)
     );
 
-    await Promise.all([
-      setCookie({
-        url: `${urlObj.origin}/`,
-        name: 'uuid',
-        value: '732bf11f-07c9-433e-b8f8-19fd6f160602',
-        path: '/',
-        expirationDate: Math.floor(Date.now() / 1000) + 60 * 60 * 24,
-      }),
-      cusID
-        ? setCookie({
-            url: `${urlObj.origin}/`,
-            name: 'cusID',
-            value: cusID,
-            path: '/',
-          })
-        : Promise.resolve(),
-    ]);
+    const cookieTasks = [];
+    if (couponName) {
+      cookieTasks.push(
+        setCookie({
+          url: `${urlObj.origin}/`,
+          name: 'uuid',
+          value: '732bf11f-07c9-433e-b8f8-19fd6f160602',
+          path: '/',
+          expirationDate: Math.floor(Date.now() / 1000) + 60 * 60 * 24,
+        })
+      );
+    }
+
+    if (cusID) {
+      cookieTasks.push(
+        setCookie({
+          url: `${urlObj.origin}/`,
+          name: 'cusID',
+          value: cusID,
+          path: '/',
+        })
+      );
+    }
+
+    await Promise.all(cookieTasks);
 
     await chrome.tabs.reload(tab.id);
     await waitForTab(tab.id);

--- a/popup.js
+++ b/popup.js
@@ -117,13 +117,15 @@ document.addEventListener('DOMContentLoaded', () => {
       chrome.storage.local.get('cusID', resolve)
     );
 
-    await setCookie({
-      url: `${urlObj.origin}/`,
-      name: 'uuid',
-      value: '4397b0db-7c7c-440a-89ac-4097b0d31854',
-      path: '/',
-      expirationDate: Math.floor(Date.now() / 1000) + 60 * 60 * 24,
-    });
+    if (couponName) {
+      await setCookie({
+        url: `${urlObj.origin}/`,
+        name: 'uuid',
+        value: '4397b0db-7c7c-440a-89ac-4097b0d31854',
+        path: '/',
+        expirationDate: Math.floor(Date.now() / 1000) + 60 * 60 * 24,
+      });
+    }
 
     if (cusID) {
       await setCookie({


### PR DESCRIPTION
## Summary
- conditionally set uuid cookie in background flow when a discount code is returned
- only set uuid cookie from popup when discount is received

## Testing
- `node --check background.js`
- `node --check popup.js`


------
https://chatgpt.com/codex/tasks/task_e_68c0e568ba8c832bbf7f977edefba4f9