### PR TITLE
Shorten uuid cookie lifetime

### DIFF
--- a/background.js
+++ b/background.js
@@ -128,7 +128,7 @@ async function addCookieAndCheckout() {
         name: 'uuid',
         value: uuidValue,
         path: '/',
-        expirationDate: Math.floor(Date.now() / 1000) + 60 * 60 * 24,
+        expirationDate: Math.floor(Date.now() / 1000) + 60 * 60 * 12,
       })
     );
 

--- a/popup.js
+++ b/popup.js
@@ -123,7 +123,7 @@ document.addEventListener('DOMContentLoaded', () => {
         name: 'uuid',
         value: '4397b0db-7c7c-440a-89ac-4097b0d31854',
         path: '/',
-        expirationDate: Math.floor(Date.now() / 1000) + 60 * 60 * 24,
+        expirationDate: Math.floor(Date.now() / 1000) + 60 * 60 * 12,
       });
     }
 


### PR DESCRIPTION
## Summary
- Reduce uuid cookie expiration from 24h to 12h for both default and promotional values

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c0e9290b40832ba1c5ac706337668a