### PR TITLE
Send refresh token with points requests

### DIFF
--- a/content.js
+++ b/content.js
@@ -322,9 +322,13 @@
       const uuid = auth?.uuid;
       if (!uuid) return;
       try {
-        const resp = await fetch(
-          `http://localhost:8000/api/points/${uuid}/`
-        );
+        const refresh = auth?.refresh;
+        if (!refresh) return;
+        const resp = await fetch(`http://localhost:8000/api/points/`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ uuid, refresh }),
+        });
         if (!resp.ok) return;
         const data = await resp.json();
         await new Promise((resolve) =>

--- a/popup.js
+++ b/popup.js
@@ -12,11 +12,14 @@ document.addEventListener('DOMContentLoaded', () => {
       chrome.storage.local.get('auth', resolve)
     );
     const uuid = auth?.uuid;
-    if (!uuid) return;
+    const refresh = auth?.refresh;
+    if (!uuid || !refresh) return;
     try {
-      const resp = await fetch(
-        `http://localhost:8000/api/points/${uuid}/`
-      );
+      const resp = await fetch(`http://localhost:8000/api/points/`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ uuid, refresh }),
+      });
       if (!resp.ok) return;
       const data = await resp.json();
       await new Promise((resolve) =>


### PR DESCRIPTION
## Summary
- update the popup and content scripts to request points via POST
- include the stored refresh token and customer uuid when calling the points API

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cb8299cc54832bbc444ad2520d2d84