### PR TITLE
Refresh points on popup open

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -186,11 +186,13 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   });
 
-    chrome.runtime.onMessage.addListener((msg) => {
-      if (msg?.type === 'LOGIN_SUCCESS') {
-        render();
-      }
-    });
+  const refreshPointsAndRender = () => updatePoints().then(render);
+
+  chrome.runtime.onMessage.addListener((msg) => {
+    if (msg?.type === 'LOGIN_SUCCESS') {
+      refreshPointsAndRender();
+    }
+  });
 
   chrome.storage.onChanged.addListener((changes, area) => {
     if (area === 'local' && changes.auth) {
@@ -198,6 +200,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  updatePoints().then(render);
+  refreshPointsAndRender();
 });
 


### PR DESCRIPTION
## Summary
- ensure popup fetches the latest point balance whenever it opens
- reuse the same refresh routine after login events

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb84ca636c832bb379b3e00a17bd85