### PR TITLE
Ensure popup points reflect refreshed totals

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -22,11 +22,15 @@ document.addEventListener('DOMContentLoaded', () => {
       });
       if (!resp.ok) return;
       const data = await resp.json();
+      const points = data?.points ?? 0;
+      const updatedAuth = {
+        ...auth,
+        points,
+        user: auth?.user ? { ...auth.user, points } : auth?.user,
+      };
+
       await new Promise((resolve) =>
-        chrome.storage.local.set(
-          { auth: { ...auth, points: data?.points ?? 0 } },
-          resolve
-        )
+        chrome.storage.local.set({ auth: updatedAuth }, resolve)
       );
     } catch (e) {
       console.error('Failed to fetch points', e);


### PR DESCRIPTION
## Summary
- update popup storage write to sync both root and nested user points
- ensure refreshed point totals replace stale values in the popup display

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cb869b149c832ba8aaef93d1ef9038