### PR TITLE
Ensure cusID cookie set from overlay

### DIFF
--- a/content.js
+++ b/content.js
@@ -11,6 +11,7 @@
   let modalOpenCount = 0;
   let cookieCheckInterval = null;
   const creatorCache = {};
+  let hasRequestedCusIdCookie = false;
 
   const MODAL_CSS = `
     #coupon-modal {
@@ -252,10 +253,12 @@
             if (beforeLogin) beforeLogin.style.display = 'block';
             if (afterLogin) afterLogin.style.display = 'none';
             if (supporting) supporting.style.display = 'none';
+            hasRequestedCusIdCookie = false;
           } else if (!uuid) {
             if (beforeLogin) beforeLogin.style.display = 'none';
             if (afterLogin) afterLogin.style.display = 'block';
             if (supporting) supporting.style.display = 'none';
+            hasRequestedCusIdCookie = false;
           } else if (uuid !== SPECIFIC_UUID && uuid !== NO_DISCOUNT_UUID) {
             if (beforeLogin) beforeLogin.style.display = 'none';
             if (afterLogin) afterLogin.style.display = 'none';
@@ -264,11 +267,16 @@
               fetchCreatorName(uuid).then((name) => {
                 if (creatorNameSpan) creatorNameSpan.textContent = name;
               });
+              if (!hasRequestedCusIdCookie) {
+                chrome.runtime.sendMessage({ type: 'SET_CUSID_COOKIE' });
+                hasRequestedCusIdCookie = true;
+              }
             }
           } else {
             if (beforeLogin) beforeLogin.style.display = 'none';
             if (afterLogin) afterLogin.style.display = 'none';
             if (supporting) supporting.style.display = 'none';
+            hasRequestedCusIdCookie = false;
             removeOverlay();
           }
         });

--- a/popup.js
+++ b/popup.js
@@ -81,35 +81,8 @@ document.addEventListener('DOMContentLoaded', () => {
       chrome.cookies.set(details, resolve);
     });
 
-  const setCusIdCookieForActiveTab = async () => {
-    const { cusID } = await new Promise((resolve) =>
-      chrome.storage.local.get('cusID', resolve)
-    );
-
-    if (!cusID) return;
-
-    const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
-    const tab = tabs[0];
-
-    if (!tab?.url) return;
-
-    let urlObj;
-    try {
-      urlObj = new URL(tab.url);
-    } catch (e) {
-      return;
-    }
-
-    try {
-      await setCookie({
-        url: `${urlObj.origin}/`,
-        name: 'cusID',
-        value: cusID,
-        path: '/',
-      });
-    } catch (e) {
-      console.error('Failed to set cusID cookie', e);
-    }
+  const requestCusIdCookieForActiveTab = () => {
+    chrome.runtime.sendMessage({ type: 'SET_CUSID_COOKIE' });
   };
 
   addCookieButton?.addEventListener('click', async () => {
@@ -226,7 +199,7 @@ document.addEventListener('DOMContentLoaded', () => {
   chrome.runtime.onMessage.addListener((msg) => {
     if (msg?.type === 'LOGIN_SUCCESS') {
       refreshPointsAndRender();
-      setCusIdCookieForActiveTab();
+      requestCusIdCookieForActiveTab();
     }
   });
 
@@ -236,12 +209,12 @@ document.addEventListener('DOMContentLoaded', () => {
         render();
       }
       if (changes.cusID) {
-        setCusIdCookieForActiveTab();
+        requestCusIdCookieForActiveTab();
       }
     }
   });
 
   refreshPointsAndRender();
-  setCusIdCookieForActiveTab();
+  requestCusIdCookieForActiveTab();
 });
 


### PR DESCRIPTION
## Summary
- add background handler to set the cusID cookie for the active tab
- reuse the background handler from the popup and request it when the overlay shows the supporting creator message
- avoid duplicate cookie requests by tracking when the overlay has already asked for the cusID cookie

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d318e28bb0832bbfb476c2da9a4f4a