### PR TITLE
Simplify popup header design

### DIFF
--- a/hello.html
+++ b/hello.html
@@ -16,7 +16,7 @@
         padding: 0;
         font-family: "Inter", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
         color: #111827;
-        background: #f4f3ef;
+        background: #ffffff;
         min-width: 320px;
       }
 
@@ -36,20 +36,6 @@
         overflow: hidden;
       }
 
-      .window-chrome {
-        background: #e9e7e0;
-        padding: 8px 14px;
-        display: flex;
-        gap: 6px;
-      }
-
-      .chrome-dot {
-        width: 8px;
-        height: 8px;
-        border-radius: 50%;
-        background: #d1cec7;
-      }
-
       .popup-inner {
         padding: 24px;
         display: flex;
@@ -59,8 +45,8 @@
 
       .popup-header {
         display: flex;
-        justify-content: space-between;
-        align-items: flex-start;
+        justify-content: center;
+        align-items: center;
       }
 
       .brand-mark {
@@ -72,73 +58,6 @@
         display: block;
         height: 28px;
         width: auto;
-      }
-
-      .menu-container {
-        position: relative;
-      }
-
-      .menu-container.hidden {
-        display: none;
-      }
-
-      .menu-trigger {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        padding: 6px;
-        border: none;
-        border-radius: 999px;
-        background: #f1efe8;
-        color: #111827;
-        cursor: pointer;
-        font-size: 16px;
-        width: 32px;
-        height: 32px;
-      }
-
-      .menu-trigger:focus-visible {
-        outline: 2px solid #111827;
-        outline-offset: 2px;
-      }
-
-      .menu-trigger-dots {
-        letter-spacing: 2px;
-      }
-
-      .menu-dropdown {
-        position: absolute;
-        top: calc(100% + 8px);
-        left: 0;
-        background: #ffffff;
-        border-radius: 12px;
-        padding: 8px;
-        box-shadow: 0 16px 32px rgba(17, 24, 39, 0.18);
-        min-width: 140px;
-        display: none;
-        z-index: 10;
-      }
-
-      .menu-dropdown.is-open {
-        display: block;
-      }
-
-      .menu-dropdown button {
-        width: 100%;
-        border: none;
-        background: none;
-        padding: 10px 12px;
-        text-align: left;
-        border-radius: 8px;
-        font-size: 14px;
-        color: #111827;
-        cursor: pointer;
-      }
-
-      .menu-dropdown button:hover,
-      .menu-dropdown button:focus-visible {
-        background: #f3f2ed;
-        outline: none;
       }
 
       .popup-content {
@@ -230,6 +149,23 @@
         align-self: flex-start;
       }
 
+      .logout-button {
+        background: transparent;
+        color: #6b7280;
+        border: none;
+        padding: 0;
+        align-self: flex-start;
+        cursor: pointer;
+        font-size: 14px;
+        font-weight: 500;
+        text-decoration: underline;
+      }
+
+      .logout-button:hover,
+      .logout-button:focus-visible {
+        color: #111827;
+      }
+
       .cta-button:hover {
         transform: translateY(-1px);
       }
@@ -252,28 +188,8 @@
   </head>
   <body>
     <div class="popup-shell">
-      <div class="window-chrome" aria-hidden="true">
-        <span class="chrome-dot"></span>
-        <span class="chrome-dot"></span>
-        <span class="chrome-dot"></span>
-      </div>
       <div class="popup-inner">
         <header class="popup-header">
-          <div class="menu-container hidden" id="menu-container">
-            <button
-              type="button"
-              class="menu-trigger"
-              id="menu-trigger"
-              aria-label="Account options"
-              aria-haspopup="true"
-              aria-expanded="false"
-            >
-              <span class="menu-trigger-dots" aria-hidden="true">•••</span>
-            </button>
-            <div class="menu-dropdown" id="menu-dropdown" role="menu">
-              <button type="button" id="logout" role="menuitem">Log out</button>
-            </div>
-          </div>
           <div class="brand-mark">
             <img src="transparent-logo.png" alt="Badger Rewards" />
           </div>
@@ -294,6 +210,7 @@
               </div>
             </div>
             <button id="add-cookie" class="cta-button secondary">Activate rewards</button>
+            <button id="logout" class="logout-button" type="button">Log out</button>
           </section>
         </main>
       </div>

--- a/popup.js
+++ b/popup.js
@@ -6,39 +6,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const logoutButton = document.getElementById('logout');
   const nameSpan = document.getElementById('user-name');
   const pointsSpan = document.getElementById('user-points');
-  const menuTrigger = document.getElementById('menu-trigger');
-  const menuDropdown = document.getElementById('menu-dropdown');
-  const menuContainer = document.getElementById('menu-container');
-
-  const closeMenu = () => {
-    if (menuDropdown) menuDropdown.classList.remove('is-open');
-    if (menuTrigger) menuTrigger.setAttribute('aria-expanded', 'false');
-  };
-
-  const toggleMenu = (event) => {
-    event?.preventDefault();
-    event?.stopPropagation();
-    if (!menuDropdown || !menuTrigger) return;
-    const willOpen = !menuDropdown.classList.contains('is-open');
-    menuDropdown.classList.toggle('is-open', willOpen);
-    menuTrigger.setAttribute('aria-expanded', willOpen ? 'true' : 'false');
-  };
-
-  menuTrigger?.addEventListener('click', toggleMenu);
-
-  document.addEventListener('click', (event) => {
-    if (!menuContainer) return;
-    if (!menuContainer.contains(event.target)) {
-      closeMenu();
-    }
-  });
-
-  document.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape') {
-      closeMenu();
-    }
-  });
-
   const updatePoints = async () => {
     const { auth } = await new Promise((resolve) =>
       chrome.storage.local.get('auth', resolve)
@@ -86,7 +53,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const points = auth?.user?.points ?? auth?.points ?? 0;
 
-        if (menuContainer) menuContainer.classList.remove('hidden');
         if (nameSpan) nameSpan.textContent = name;
         if (pointsSpan) {
           const numericPoints = Number(points) || 0;
@@ -95,8 +61,6 @@ document.addEventListener('DOMContentLoaded', () => {
         if (beforeLogin) beforeLogin.style.display = 'none';
         if (afterLogin) afterLogin.style.display = 'flex';
       } else {
-        if (menuContainer) menuContainer.classList.add('hidden');
-        closeMenu();
         if (beforeLogin) beforeLogin.style.display = 'flex';
         if (afterLogin) afterLogin.style.display = 'none';
       }
@@ -228,7 +192,6 @@ document.addEventListener('DOMContentLoaded', () => {
   logoutButton?.addEventListener('click', () => {
     chrome.storage.local.remove(['auth', 'cusID'], () => {
       chrome.runtime.sendMessage({ type: 'LOGOUT' });
-      closeMenu();
       render();
     });
   });


### PR DESCRIPTION
## Summary
- remove the faux window chrome and overflow menu from the popup header for a cleaner layout
- add a direct logout button within the signed-in state and keep the popup background solid white
- simplify popup scripting by deleting unused menu logic

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daaecd0620832b83ab664549da2541