### PR TITLE
Remove Activate rewards button from popup

### DIFF
--- a/hello.html
+++ b/hello.html
@@ -209,7 +209,6 @@
                 <div class="points-label">pts</div>
               </div>
             </div>
-            <button id="add-cookie" class="cta-button secondary">Activate rewards</button>
             <button id="logout" class="logout-button" type="button">Log out</button>
           </section>
         </main>


### PR DESCRIPTION
## Summary
- remove the Activate rewards button from the popup so users cannot trigger the action

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dab51ccd40832b848d6ba08ced53c2