### PR TITLE
Ensure coupon overlay uses bundled logo asset

### DIFF
--- a/content.js
+++ b/content.js
@@ -168,6 +168,10 @@
 
       const template = document.createElement('div');
       template.innerHTML = html;
+      const brandMarkImg = template.querySelector('.brand-mark img');
+      if (brandMarkImg) {
+        brandMarkImg.src = chrome.runtime.getURL('transparent-logo.png');
+      }
       shadow.appendChild(template.firstElementChild);
       document.documentElement.appendChild(host);
 

--- a/manifest.json
+++ b/manifest.json
@@ -26,7 +26,7 @@
   },
   "web_accessible_resources": [
     {
-      "resources": ["styles.css", "ui-popup.html"],
+      "resources": ["styles.css", "ui-popup.html", "transparent-logo.png"],
       "matches": ["<all_urls>"]
     }
   ],


### PR DESCRIPTION
## Summary
- set the coupon overlay brand mark image source using chrome.runtime.getURL
- expose the transparent logo as a web accessible resource

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dc980e308c832b83e80ccf152e9531