### PR TITLE
Redesign supporting creator section

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -123,6 +123,47 @@
   line-height: 1.4;
 }
 
+.supporting-state {
+  background: #ffffff;
+  border: 1px solid #efece4;
+  position: relative;
+}
+
+.supporting-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.supporting-logo {
+  align-self: flex-end;
+  width: 80px;
+  height: auto;
+}
+
+.supporting-illustration {
+  width: 96px;
+  height: auto;
+  align-self: center;
+}
+
+.supporting-message {
+  background: #fcd965;
+  border-radius: 16px;
+  padding: 20px;
+  color: #3d2b05;
+  box-shadow: 0 12px 18px rgba(252, 217, 101, 0.32);
+  align-self: stretch;
+}
+
+.supporting-message p {
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.4;
+  font-weight: 600;
+  text-align: center;
+}
+
 .cta-button {
   border: none;
   border-radius: 999px;

--- a/ui-popup.html
+++ b/ui-popup.html
@@ -17,8 +17,22 @@
         <p class="deal-subtitle">Let us get a deal for you</p>
         <button id="add-cookie" class="cta-button run-badger">Run Badger</button>
       </section>
-      <section id="supporting-creator" class="state highlight" style="display: none;">
-        <p>You are supporting <span id="creator-name"></span> with this purchase.</p>
+      <section id="supporting-creator" class="state supporting-state" style="display: none;">
+        <div class="supporting-card" role="group" aria-label="Support creator message">
+          <img
+            class="supporting-logo"
+            src="transparent-logo.png"
+            alt="Badger Rewards logo"
+          />
+          <img
+            class="supporting-illustration"
+            src="party-horn.png"
+            alt="Party horn illustration"
+          />
+          <div class="supporting-message">
+            <p>You are supporting <span id="creator-name"></span> with this purchase.</p>
+          </div>
+        </div>
       </section>
     </main>
   </div>


### PR DESCRIPTION
## Summary
- restyle the supporting creator state with a dedicated card and celebratory imagery
- add layout and color styling to highlight the #fcd965 message banner

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcac6c826c832b93dbd0131e866979