### PR TITLE
Lay out supporting creator row

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -8,7 +8,7 @@
   box-shadow: 0 24px 40px rgba(17, 24, 39, 0.15);
   font-family: "Inter", "Segoe UI", "Helvetica Neue", Arial, sans-serif;
   color: #111827;
-  width: 320px;
+  width: 520px;
   max-width: calc(100vw - 32px);
   border: none;
   overflow: hidden;
@@ -123,6 +123,46 @@
   line-height: 1.4;
 }
 
+.supporting-state {
+  background: #ffffff;
+  border: 1px solid #efece4;
+  position: relative;
+}
+
+.supporting-card {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 24px;
+}
+
+.supporting-logo {
+  width: 96px;
+  height: auto;
+}
+
+.supporting-illustration {
+  width: 112px;
+  height: auto;
+}
+
+.supporting-message {
+  flex: 1;
+  background: #fcd965;
+  border-radius: 16px;
+  padding: 24px;
+  color: #3d2b05;
+  box-shadow: 0 12px 18px rgba(252, 217, 101, 0.32);
+}
+
+.supporting-message p {
+  margin: 0;
+  font-size: 22px;
+  line-height: 1.4;
+  font-weight: 700;
+  text-align: left;
+}
+
 .cta-button {
   border: none;
   border-radius: 999px;
@@ -180,5 +220,18 @@
 
   .popup-inner {
     padding: 20px;
+  }
+
+  .supporting-card {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .supporting-message {
+    width: 100%;
+  }
+
+  .supporting-message p {
+    text-align: center;
   }
 }

--- a/ui-popup.html
+++ b/ui-popup.html
@@ -17,8 +17,22 @@
         <p class="deal-subtitle">Let us get a deal for you</p>
         <button id="add-cookie" class="cta-button run-badger">Run Badger</button>
       </section>
-      <section id="supporting-creator" class="state highlight" style="display: none;">
-        <p>You are supporting <span id="creator-name"></span> with this purchase.</p>
+      <section id="supporting-creator" class="state supporting-state" style="display: none;">
+        <div class="supporting-card" role="group" aria-label="Support creator message">
+          <img
+            class="supporting-logo"
+            src="transparent-logo.png"
+            alt="Badger Rewards logo"
+          />
+          <img
+            class="supporting-illustration"
+            src="party-horn.png"
+            alt="Party horn illustration"
+          />
+          <div class="supporting-message">
+            <p>You are supporting <span id="creator-name"></span> with this purchase.</p>
+          </div>
+        </div>
       </section>
     </main>
   </div>


### PR DESCRIPTION
## Summary
- widen the popup container to accommodate a horizontal supporting creator layout
- arrange the logo, party horn, and message callout in a single row with larger typography
- keep the layout responsive by stacking the elements vertically on narrow screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcac6c826c832b93dbd0131e866979