### PR TITLE
Update supporting creator card styling

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -26,7 +26,12 @@
   },
   "web_accessible_resources": [
     {
-      "resources": ["styles.css", "ui-popup.html", "transparent-logo.png"],
+      "resources": [
+        "styles.css",
+        "ui-popup.html",
+        "transparent-logo.png",
+        "party-horn.png"
+      ],
       "matches": ["<all_urls>"]
     }
   ],

--- a/styles.css
+++ b/styles.css
@@ -136,31 +136,36 @@
   align-items: center;
 }
 
-.supporting-logo {
-  width: 96px;
-  height: auto;
-}
-
 .supporting-illustration {
   width: 120px;
   height: auto;
+  display: block;
 }
 
 .supporting-message {
-  background: #fcd965;
-  border-radius: 16px;
-  padding: 24px;
-  color: #3d2b05;
-  box-shadow: 0 12px 18px rgba(252, 217, 101, 0.32);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
   flex: 1;
 }
 
-.supporting-message p {
+.supporting-title {
   margin: 0;
-  font-size: 20px;
+  font-size: 26px;
+  font-weight: 700;
+  line-height: 1.2;
+  color: #111827;
+}
+
+.supporting-title span {
+  color: #b45309;
+}
+
+.supporting-subtitle {
+  margin: 0;
+  font-size: 16px;
   line-height: 1.5;
-  font-weight: 600;
-  text-align: left;
+  color: #4b5563;
 }
 
 .cta-button {

--- a/ui-popup.html
+++ b/ui-popup.html
@@ -20,17 +20,17 @@
       <section id="supporting-creator" class="state supporting-state" style="display: none;">
         <div class="supporting-card" role="group" aria-label="Support creator message">
           <img
-            class="supporting-logo"
-            src="transparent-logo.png"
-            alt="Badger Rewards logo"
-          />
-          <img
             class="supporting-illustration"
-            src="party-horn.png"
+            src="./party-horn.png"
             alt="Party horn illustration"
           />
           <div class="supporting-message">
-            <p>You are supporting <span id="creator-name"></span> with this purchase.</p>
+            <h2 class="supporting-title">
+              You are supporting <span id="creator-name"></span>
+            </h2>
+            <p class="supporting-subtitle">
+              Thanks for helping your favorite creator earn rewards.
+            </p>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- restyle the supporting creator card to highlight the message and remove the Badger logo beside the illustration
- ensure the party horn illustration path resolves correctly and add descriptive copy
- expose the party horn asset in the manifest so it loads inside the extension popup

## Testing
- Screenshot: Added `browser:/invocations/aowfekex/artifacts/artifacts/supporting-card.png`


------
https://chatgpt.com/codex/tasks/task_e_68dd9028ddc4832bb133639a46945441