### PR TITLE
Fix party horn image path

### DIFF
--- a/content.js
+++ b/content.js
@@ -172,6 +172,10 @@
       if (brandMarkImg) {
         brandMarkImg.src = chrome.runtime.getURL('transparent-logo.png');
       }
+      const supportingIllustration = template.querySelector('.supporting-illustration');
+      if (supportingIllustration) {
+        supportingIllustration.src = chrome.runtime.getURL('party-horn.png');
+      }
       shadow.appendChild(template.firstElementChild);
       document.documentElement.appendChild(host);
 


### PR DESCRIPTION
## Summary
- ensure the supporting creator illustration loads from the extension package rather than the host page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd929d79d0832ba1df9ba0f62a7bd0