### PR TITLE
Use 1000-point numeric levels with rolling progress

### DIFF
--- a/content.js
+++ b/content.js
@@ -3,7 +3,7 @@
   const SPECIFIC_UUID = '733d0d67-6a30-4c48-a92e-b8e211b490f5';
   const NO_DISCOUNT_UUID = 'n/a';
   const REWARD_LAYER_ID = 'badger-reward-layer';
-  const REWARD_POINTS_PER_LEVEL = 500;
+  const REWARD_POINTS_PER_LEVEL = 1000;
   const REWARD_ICON = '⭐';
   const REWARD_ANIMATION_DURATION = 900;
   let escHandler = null;

--- a/hello.html
+++ b/hello.html
@@ -307,7 +307,7 @@
           <div class="user-card">
             <div class="user-meta">
               <p class="greeting">Hi, <span id="user-name">there</span></p>
-              <span class="level-pill" data-level-name>Level 1 · Starter</span>
+              <span class="level-pill" data-level-name>Level 1</span>
             </div>
             <div class="rewards-hud" aria-live="polite">
               <div class="rewards-meter">
@@ -328,7 +328,7 @@
           <div class="level-progress">
             <div class="level-details">
               <span>Next level</span>
-              <span class="level-next" data-level-next>Scout at 1,000 pts</span>
+              <span class="level-next" data-level-next>Level 2 at 1,000 pts</span>
             </div>
             <div class="level-details">
               <span data-level-remaining>1,000 pts to go</span>

--- a/popup.js
+++ b/popup.js
@@ -13,14 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const levelNext = document.querySelector('[data-level-next]');
   const levelRemaining = document.querySelector('[data-level-remaining]');
   const levelProgress = document.querySelector('[data-level-progress]');
-  const LEVELS = [
-    { name: 'Starter', minPoints: 0 },
-    { name: 'Scout', minPoints: 1000 },
-    { name: 'Builder', minPoints: 2500 },
-    { name: 'Trailblazer', minPoints: 5000 },
-    { name: 'Vanguard', minPoints: 9000 },
-    { name: 'Legend', minPoints: 15000 },
-  ];
+  const POINTS_PER_LEVEL = 1000;
   const updatePoints = async () => {
     const { auth } = await new Promise((resolve) =>
       chrome.storage.local.get('auth', resolve)
@@ -72,30 +65,26 @@ document.addEventListener('DOMContentLoaded', () => {
       savingsSpan.textContent = `$${numericSavings.toLocaleString('en-US')}`;
     }
     if (meterFill) {
-      const currentIndex = LEVELS.reduce(
-        (acc, level, index) => (numericPoints >= level.minPoints ? index : acc),
-        0
-      );
-      const currentLevel = LEVELS[currentIndex];
-      const nextLevel = LEVELS[currentIndex + 1];
-      const progress = nextLevel
-        ? (numericPoints - currentLevel.minPoints) /
-          (nextLevel.minPoints - currentLevel.minPoints)
-        : 1;
+      const currentLevelNumber = Math.floor(numericPoints / POINTS_PER_LEVEL) + 1;
+      const nextLevelPoints = currentLevelNumber * POINTS_PER_LEVEL;
+      const progress =
+        POINTS_PER_LEVEL === 0
+          ? 0
+          : (numericPoints % POINTS_PER_LEVEL) / POINTS_PER_LEVEL;
       meterFill.style.transform = `scaleX(${Math.min(Math.max(progress, 0), 1)})`;
 
       if (levelName) {
-        levelName.textContent = `Level ${currentIndex + 1} · ${currentLevel.name}`;
+        levelName.textContent = `Level ${currentLevelNumber}`;
       }
       if (levelNext) {
-        levelNext.textContent = nextLevel
-          ? `${nextLevel.name} at ${nextLevel.minPoints.toLocaleString('en-US')} pts`
-          : 'Max level reached';
+        levelNext.textContent = `Level ${currentLevelNumber + 1} at ${nextLevelPoints.toLocaleString(
+          'en-US'
+        )} pts`;
       }
       if (levelRemaining) {
-        levelRemaining.textContent = nextLevel
-          ? `${(nextLevel.minPoints - numericPoints).toLocaleString('en-US')} pts to go`
-          : 'You are at the top!';
+        levelRemaining.textContent = `${(nextLevelPoints - numericPoints).toLocaleString(
+          'en-US'
+        )} pts to go`;
       }
       if (levelProgress) {
         levelProgress.textContent = `${Math.round(progress * 100)}%`;


### PR DESCRIPTION
### Motivation
- Replace named ranks with simple numbered levels that advance every 1,000 points and show rolling progress within each 1,000-point tier so the meter fills between tier boundaries and resets on level-up.

### Description
- Replace the named `LEVELS` array in `popup.js` with `POINTS_PER_LEVEL = 1000` and compute `currentLevelNumber` and `progress` using `numericPoints % POINTS_PER_LEVEL` so progress is relative to the current 1,000-point tier.
- Update the popup UI text to show just `Level N` and update `levelNext`/`levelRemaining` to reference numeric levels and the next 1,000-point threshold in `hello.html`.
- Align the overlay meter tier size by changing `REWARD_POINTS_PER_LEVEL` from 500 to 1000 in `content.js` so the page overlay and popup use the same tier size.

### Testing
- Served the extension UI with `python -m http.server 8001` and used a Playwright script to load `hello.html` and capture a screenshot at `artifacts/level-progress.png`, which completed successfully.
- Verified changes are staged and committed; the repository shows the three modified files (`popup.js`, `hello.html`, `content.js`) committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697431730cc4832b9008d6b2613f7986)